### PR TITLE
Use relative imports to reduce redundancy

### DIFF
--- a/workalendar/africa.py
+++ b/workalendar/africa.py
@@ -2,9 +2,9 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from datetime import timedelta, date
-from workalendar.core import WesternCalendar
-from workalendar.core import SUN
-from workalendar.core import IslamicMixin, ChristianMixin
+from .core import WesternCalendar
+from .core import SUN
+from .core import IslamicMixin, ChristianMixin
 
 
 class Algeria(WesternCalendar, IslamicMixin):

--- a/workalendar/america.py
+++ b/workalendar/america.py
@@ -3,8 +3,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from datetime import date, timedelta
-from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.core import SUN, MON, TUE, WED, FRI, SAT
+from .core import WesternCalendar, ChristianMixin
+from .core import SUN, MON, TUE, WED, FRI, SAT
 
 
 class Brazil(WesternCalendar, ChristianMixin):

--- a/workalendar/asia.py
+++ b/workalendar/asia.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from datetime import timedelta
-from workalendar.core import LunarCalendar, WesternCalendar, Calendar
-from workalendar.core import MON, FRI, SAT, IslamicMixin, EphemMixin
+from .core import LunarCalendar, WesternCalendar, Calendar
+from .core import MON, FRI, SAT, IslamicMixin, EphemMixin
 
 
 class SouthKorea(LunarCalendar):

--- a/workalendar/canada.py
+++ b/workalendar/canada.py
@@ -3,8 +3,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from datetime import date
-from workalendar.core import WesternCalendar, ChristianMixin, Calendar
-from workalendar.core import SUN, MON, SAT
+from .core import WesternCalendar, ChristianMixin, Calendar
+from .core import SUN, MON, SAT
 
 
 class Canada(WesternCalendar, ChristianMixin):

--- a/workalendar/europe.py
+++ b/workalendar/europe.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
+
 from datetime import date, timedelta
-from workalendar.core import WesternCalendar, ChristianMixin, OrthodoxMixin
-from workalendar.core import THU, MON, FRI, SAT
+from .core import WesternCalendar, ChristianMixin, OrthodoxMixin
+from .core import THU, MON, FRI, SAT
 
 
 class CzechRepublic(WesternCalendar, ChristianMixin):

--- a/workalendar/oceania.py
+++ b/workalendar/oceania.py
@@ -1,5 +1,5 @@
-from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.core import MON, TUE, FRI
+from .core import WesternCalendar, ChristianMixin
+from .core import MON, TUE, FRI
 from datetime import date
 
 

--- a/workalendar/tests/__init__.py
+++ b/workalendar/tests/__init__.py
@@ -2,7 +2,7 @@ import warnings
 from datetime import date
 from unittest import TestCase
 
-from workalendar.core import Calendar
+from ..core import Calendar
 
 
 class GenericCalendarTest(TestCase):

--- a/workalendar/tests/test_africa.py
+++ b/workalendar/tests/test_africa.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from datetime import date
-from workalendar.tests import GenericCalendarTest
-from workalendar.africa import Benin, Algeria
-from workalendar.africa import SouthAfrica, IvoryCoast
-from workalendar.africa import SaoTomeAndPrincipe, Madagascar
+from . import GenericCalendarTest
+from ..africa import Benin, Algeria
+from ..africa import SouthAfrica, IvoryCoast
+from ..africa import SaoTomeAndPrincipe, Madagascar
 
 
 class AlgeriaTest(GenericCalendarTest):

--- a/workalendar/tests/test_america.py
+++ b/workalendar/tests/test_america.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from datetime import date
-from workalendar.tests import GenericCalendarTest
-from workalendar.america import Brazil, BrazilSaoPauloState
-from workalendar.america import BrazilSaoPauloCity
-from workalendar.america import Mexico, Chile, Panama
+from . import GenericCalendarTest
+from ..america import Brazil, BrazilSaoPauloState
+from ..america import BrazilSaoPauloCity
+from ..america import Mexico, Chile, Panama
 
 
 class BrazilTest(GenericCalendarTest):

--- a/workalendar/tests/test_asia.py
+++ b/workalendar/tests/test_asia.py
@@ -1,8 +1,8 @@
 from datetime import date
-from workalendar.tests import GenericCalendarTest
-from workalendar.asia import SouthKorea, Japan
-from workalendar.asia import Qatar
-from workalendar.asia import Taiwan
+from . import GenericCalendarTest
+from ..asia import SouthKorea, Japan
+from ..asia import Qatar
+from ..asia import Taiwan
 
 
 class SouthKoreaTest(GenericCalendarTest):

--- a/workalendar/tests/test_canada.py
+++ b/workalendar/tests/test_canada.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from datetime import date
-from workalendar.tests import GenericCalendarTest
-from workalendar.canada import Canada, Ontario, Quebec, BritishColumbia
-from workalendar.canada import Alberta, Saskatchewan, Manitoba, NewBrunswick
-from workalendar.canada import NovaScotia, PrinceEdwardIsland, Newfoundland
-from workalendar.canada import Yukon, NorthwestTerritories, Nunavut
+from . import GenericCalendarTest
+from ..canada import Canada, Ontario, Quebec, BritishColumbia
+from ..canada import Alberta, Saskatchewan, Manitoba, NewBrunswick
+from ..canada import NovaScotia, PrinceEdwardIsland, Newfoundland
+from ..canada import Yukon, NorthwestTerritories, Nunavut
 
 
 class CanadaTest(GenericCalendarTest):

--- a/workalendar/tests/test_core.py
+++ b/workalendar/tests/test_core.py
@@ -1,10 +1,10 @@
 from datetime import date
 from datetime import datetime
-from workalendar.tests import GenericCalendarTest
-from workalendar.core import MON, TUE, THU, FRI
-from workalendar.core import Calendar, LunarCalendar, WesternCalendar
-from workalendar.core import IslamicMixin, JalaliMixin, ChristianMixin
-from workalendar.core import EphemMixin
+from . import GenericCalendarTest
+from ..core import MON, TUE, THU, FRI
+from ..core import Calendar, LunarCalendar, WesternCalendar
+from ..core import IslamicMixin, JalaliMixin, ChristianMixin
+from ..core import EphemMixin
 
 
 class CalendarTest(GenericCalendarTest):

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -15,11 +15,11 @@ from ..europe import UnitedKingdomNorthernIreland
 from ..europe import EuropeanCentralBank
 from ..europe import Belgium
 from ..europe import (Germany, BadenWurttemberg, Bavaria, Berlin,
-                                Brandenburg, Bremen, Hamburg, Hesse,
-                                MecklenburgVorpommern, LowerSaxony,
-                                NorthRhineWestphalia, RhinelandPalatinate,
-                                Saarland, Saxony, SaxonyAnhalt,
-                                SchleswigHolstein, Thuringia)
+                      Brandenburg, Bremen, Hamburg, Hesse,
+                      MecklenburgVorpommern, LowerSaxony,
+                      NorthRhineWestphalia, RhinelandPalatinate,
+                      Saarland, Saxony, SaxonyAnhalt,
+                      SchleswigHolstein, Thuringia)
 
 
 class CzechRepublicTest(GenericCalendarTest):

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -1,20 +1,20 @@
 from datetime import date
-from workalendar.tests import GenericCalendarTest
-from workalendar.europe import CzechRepublic
-from workalendar.europe import Finland
-from workalendar.europe import Sweden
-from workalendar.europe import France, FranceAlsaceMoselle
-from workalendar.europe import Greece
-from workalendar.europe import Hungary
-from workalendar.europe import Iceland
-from workalendar.europe import Italy
-from workalendar.europe import Norway
-from workalendar.europe import Poland
-from workalendar.europe import UnitedKingdom
-from workalendar.europe import UnitedKingdomNorthernIreland
-from workalendar.europe import EuropeanCentralBank
-from workalendar.europe import Belgium
-from workalendar.europe import (Germany, BadenWurttemberg, Bavaria, Berlin,
+from . import GenericCalendarTest
+from ..europe import CzechRepublic
+from ..europe import Finland
+from ..europe import Sweden
+from ..europe import France, FranceAlsaceMoselle
+from ..europe import Greece
+from ..europe import Hungary
+from ..europe import Iceland
+from ..europe import Italy
+from ..europe import Norway
+from ..europe import Poland
+from ..europe import UnitedKingdom
+from ..europe import UnitedKingdomNorthernIreland
+from ..europe import EuropeanCentralBank
+from ..europe import Belgium
+from ..europe import (Germany, BadenWurttemberg, Bavaria, Berlin,
                                 Brandenburg, Bremen, Hamburg, Hesse,
                                 MecklenburgVorpommern, LowerSaxony,
                                 NorthRhineWestphalia, RhinelandPalatinate,

--- a/workalendar/tests/test_oceania.py
+++ b/workalendar/tests/test_oceania.py
@@ -1,16 +1,16 @@
 from datetime import date
 
-from workalendar.tests import GenericCalendarTest
-from workalendar.oceania import Australia
-from workalendar.oceania import AustraliaCapitalTerritory
-from workalendar.oceania import AustraliaNewSouthWales
-from workalendar.oceania import AustraliaNorthernTerritory
-from workalendar.oceania import AustraliaQueensland
-from workalendar.oceania import SouthAustralia
-from workalendar.oceania import Tasmania, Hobart
-from workalendar.oceania import Victoria
-from workalendar.oceania import WesternAustralia
-from workalendar.oceania import MarshallIslands
+from . import GenericCalendarTest
+from ..oceania import Australia
+from ..oceania import AustraliaCapitalTerritory
+from ..oceania import AustraliaNewSouthWales
+from ..oceania import AustraliaNorthernTerritory
+from ..oceania import AustraliaQueensland
+from ..oceania import SouthAustralia
+from ..oceania import Tasmania, Hobart
+from ..oceania import Victoria
+from ..oceania import WesternAustralia
+from ..oceania import MarshallIslands
 
 
 class AustraliaTest(GenericCalendarTest):

--- a/workalendar/tests/test_usa.py
+++ b/workalendar/tests/test_usa.py
@@ -2,17 +2,17 @@
 from datetime import date
 from . import GenericCalendarTest
 from ..usa import (UnitedStates, Alabama, Florida, Arkansas,
-                             Alaska, Arizona, California, Colorado,
-                             Connecticut, Delaware, Georgia, Indiana,
-                             Illinois, Idaho, Iowa, Kansas, Kentucky,
-                             Louisiana, Maine, Maryland, Massachusetts,
-                             Minnesota, Michigan, Mississippi, Missouri,
-                             Montana, Nebraska, Nevada, NewHampshire,
-                             NewJersey, NewMexico, NewYork, NorthCarolina,
-                             NorthDakota, Ohio, Oklahoma, Oregon, Pennsylvania,
-                             RhodeIsland, SouthCarolina, SouthDakota,
-                             Tennessee, Texas, Utah, Vermont, Virginia,
-                             Washington, WestVirginia, Wisconsin, Wyoming)
+                   Alaska, Arizona, California, Colorado,
+                   Connecticut, Delaware, Georgia, Indiana,
+                   Illinois, Idaho, Iowa, Kansas, Kentucky,
+                   Louisiana, Maine, Maryland, Massachusetts,
+                   Minnesota, Michigan, Mississippi, Missouri,
+                   Montana, Nebraska, Nevada, NewHampshire,
+                   NewJersey, NewMexico, NewYork, NorthCarolina,
+                   NorthDakota, Ohio, Oklahoma, Oregon, Pennsylvania,
+                   RhodeIsland, SouthCarolina, SouthDakota,
+                   Tennessee, Texas, Utah, Vermont, Virginia,
+                   Washington, WestVirginia, Wisconsin, Wyoming)
 
 
 class UnitedStatesTest(GenericCalendarTest):

--- a/workalendar/tests/test_usa.py
+++ b/workalendar/tests/test_usa.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import date
-from workalendar.tests import GenericCalendarTest
-from workalendar.usa import (UnitedStates, Alabama, Florida, Arkansas,
+from . import GenericCalendarTest
+from ..usa import (UnitedStates, Alabama, Florida, Arkansas,
                              Alaska, Arizona, California, Colorado,
                              Connecticut, Delaware, Georgia, Indiana,
                              Illinois, Idaho, Iowa, Kansas, Kentucky,

--- a/workalendar/usa.py
+++ b/workalendar/usa.py
@@ -3,8 +3,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from datetime import date, timedelta
-from workalendar.core import WesternCalendar, ChristianMixin, Calendar
-from workalendar.core import SUN, MON, TUE, WED, THU, FRI, SAT
+from .core import WesternCalendar, ChristianMixin, Calendar
+from .core import SUN, MON, TUE, WED, THU, FRI, SAT
 
 NONE, NEAREST_WEEKDAY, MONDAY = range(3)
 


### PR DESCRIPTION
...and to allow project to operate under a different package name.

As I think about what it will take to support a fork of workalendar, one thing that will make it much easier is for the project to use relative imports. In this way, the package name 'workalendar' must only be changed in two places to support relocation of the package and functionality.