### PR TITLE
added datetime to date conversion to is_holiday() like in is_working_day()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ master (unreleased)
 
 - Added Denmark (#117).
 - Tiny fixes in the ``usa.py`` module (flake8 + typo) (#122)
+- Added datetime to date conversion in is_holiday()
 
 0.4.2 (2015-12-23)
 ------------------

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -105,6 +105,10 @@ class Calendar(object):
         holidays, even if not in the regular calendar holidays (or weekends).
 
         """
+        # a little exception: chop the datetime type
+        if type(day) is datetime:
+            day = day.date()
+
         if extra_holidays and day in extra_holidays:
             return True
 

--- a/workalendar/tests/test_core.py
+++ b/workalendar/tests/test_core.py
@@ -212,6 +212,8 @@ class MockCalendarTest(GenericCalendarTest):
     def test_datetime(self):
         self.assertFalse(
             self.cal.is_working_day(datetime(2014, 1, 1)))
+        self.assertTrue(
+            self.cal.is_holiday(datetime(2014, 1, 1)))
 
     def test_add_working_days_backwards(self):
         day = date(self.year, 1, 3)


### PR DESCRIPTION
I think both methods should behave the same if a datetime object is given.