### PR TITLE
switch to py.test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 build/
 .coverage
 .tox/
+# py.test cache
+.cache/

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,8 @@ master (unreleased)
 
 - Easter Sunday is a Brandenburg federate state holiday (#143), thx @uvchik.
 - Added Catalonia (#145), thx @ferranp.
-- Use `find_packages()` to fetch package directories in `setup.py` (#141, #144)
+- Use `find_packages()` to fetch package directories in `setup.py` (#141, #144).
+- use py.test instead of nosetests for tests (#146).
 
 0.6.1 (2016-06-29)
 ------------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -119,7 +119,7 @@ file and add the following code::
             self.assertIn(date(2014, 4, 21), holidays)  # easter monday
             self.assertIn(date(2014, 6, 2), holidays)  # First MON in June
 
-of course, if you run the test using the ``tox`` or ``nosetests`` command,
+of course, if you run the test using the ``tox`` or ``py.test`` command,
 this will fail, since we haven't implemented anything yet.
 
 Install tox using the following command::

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,12 @@ envlist = py27,flake8,py33,py34,py35
 
 [testenv]
 deps =
-    nose
-    coverage
+    pytest
+    pytest-cov
 
 commands =
     python setup.py develop
-    nosetests -sv --with-coverage --cover-package=workalendar {posargs: workalendar}
+    py.test --cov=workalendar {posargs: workalendar}
     pip freeze
     python --version
 


### PR DESCRIPTION
this pure-python project could have its tests executed via py.test instead of nosetests