### PR TITLE
Bugfix: New Year's Eve is not a holiday in Netherlands

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,8 @@ CHANGELOG
 master (unreleased)
 -------------------
 
-- Add Ireland. thx @gregn610 (#152)
+- Add Ireland. thx @gregn610 (#152).
+- Bugfix: New Year's Eve is not a holiday in Netherlands (#154).
 
 
 0.8.1 (2016-11-08)

--- a/workalendar/europe/netherlands.py
+++ b/workalendar/europe/netherlands.py
@@ -15,7 +15,6 @@ class Netherlands(WesternCalendar, ChristianMixin):
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (5, 5, "Liberation Day"),
-        (12, 31, "New Year's Eve"),
     )
 
     def get_king_queen_day(self, year):

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -474,6 +474,12 @@ class NetherlandsTest(GenericCalendarTest):
         holidays = self.cal.holidays_set(1990)
         self.assertIn(date(1990, 4, 30), holidays)   # Queen's Day
 
+    def test_new_years_eve(self):
+        # For some reason, the new year's eve was added to the list of fixed
+        # holidays. It appears it's not a holiday
+        holidays = self.cal.holidays_set(2016)
+        self.assertNotIn(date(2016, 12, 31), holidays)
+
 
 class UnitedKingdomTest(GenericCalendarTest):
     cal_class = UnitedKingdom


### PR DESCRIPTION
refs #154

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.

