### PR TITLE
Remove the status telling the lib is beta.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,12 +10,6 @@ list legal / religious holidays and gives working-day-related computation
 functions.
 
 
-Status
-======
-
-This is barely beta. Please consider this module as a work in progres.
-
-
 Usage sample
 ============
 


### PR DESCRIPTION
refs #161 

- [x] lib is not beta anymore,
- [ ] change and refresh ``setup.py`` classifiers
- [ ] prepare for 1.0.0, which will be the next release