### PR TITLE
Add tests for Spain'17

### DIFF
--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -943,6 +943,18 @@ class SpainTest(GenericCalendarTest):
         self.assertIn(date(2016, 12, 6), holidays)
         self.assertIn(date(2016, 12, 8), holidays)
 
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 1, 1), holidays)
+        self.assertIn(date(2017, 1, 6), holidays)
+        self.assertIn(date(2017, 4, 14), holidays)
+        self.assertIn(date(2017, 8, 15), holidays)
+        self.assertIn(date(2017, 10, 12), holidays)
+        self.assertIn(date(2017, 11, 1), holidays)
+        self.assertIn(date(2017, 12, 6), holidays)
+        self.assertIn(date(2017, 12, 8), holidays)
+        self.assertIn(date(2017, 12, 25), holidays)
+
 
 class CataloniaTest(GenericCalendarTest):
     cal_class = Catalonia


### PR DESCRIPTION
Add tests for Spain holidays in 2017

- [x] Tests with a significant number of years to be tested for your calendar.
- [ ] Changelog amended with a mention describing your changes.
