### PR TITLE
Switzerland: add rules for canton of Vaud

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+1.1.0 (unreleased)
+------------------
+
+- Added Canton of Vaud (Switzerland) by @brutasse
+
 1.0.0 (2016-12-12)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,7 @@ Europe
 * Spain (incl. Catalonia)
 * Slovenia
 * Switzerland
+  * Vaud
 
 America
 -------

--- a/workalendar/europe/__init__.py
+++ b/workalendar/europe/__init__.py
@@ -23,7 +23,7 @@ from .slovakia import Slovakia
 from .slovenia import Slovenia
 from .spain import Spain, Catalonia
 from .sweden import Sweden
-from .switzerland import Switzerland
+from .switzerland import Switzerland, Vaud
 from .united_kingdom import UnitedKingdom, UnitedKingdomNorthernIreland
 
 # Germany
@@ -63,6 +63,7 @@ __all__ = (
     Spain,
     Sweden,
     Switzerland,
+    Vaud,
     UnitedKingdom,
     UnitedKingdomNorthernIreland,
 

--- a/workalendar/europe/switzerland.py
+++ b/workalendar/europe/switzerland.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from datetime import date, timedelta
+
 from workalendar.core import WesternCalendar, ChristianMixin
 
 
@@ -19,3 +21,30 @@ class Switzerland(WesternCalendar, ChristianMixin):
         (5, 1, "Labour Day"),
         (8, 1, "National Holiday"),
     )
+
+
+class Vaud(Switzerland):
+    """Canton of Vaud"""
+    include_boxing_day = False
+    include_federal_thanksgiving_monday = True
+
+    FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
+        (1, 2, "Berchtold's Day"),
+        (8, 1, "National Holiday"),
+    )
+
+    def get_federal_thanksgiving_monday(self, year):
+        "Monday following the 3rd sunday of September"
+        september_1st = date(year, 9, 1)
+        return (
+            september_1st +
+            (6 - september_1st.weekday()) * timedelta(days=1) +  # 1st sunday
+            timedelta(days=15)  # Monday following 3rd sunday
+        )
+
+    def get_variable_days(self, year):
+        days = super(Vaud, self).get_variable_days(year)
+        if self.include_federal_thanksgiving_monday:
+            days.append((self.get_federal_thanksgiving_monday(year),
+                         "Federal Thanksgiving Monday"))
+        return days

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -24,7 +24,7 @@ from workalendar.europe import Poland
 from workalendar.europe import Portugal
 from workalendar.europe import Spain, Catalonia
 from workalendar.europe import Slovenia
-from workalendar.europe import Switzerland
+from workalendar.europe import Switzerland, Vaud
 from workalendar.europe import UnitedKingdom
 from workalendar.europe import UnitedKingdomNorthernIreland
 from workalendar.europe import EuropeanCentralBank
@@ -1050,6 +1050,22 @@ class SwitzerlandTest(GenericCalendarTest):
         self.assertIn(date(2016, 8, 1), holidays)
         self.assertIn(date(2016, 12, 25), holidays)
         self.assertIn(date(2016, 12, 26), holidays)
+
+
+class VaudTest(GenericCalendarTest):
+    cal_class = Vaud
+
+    def test_year_2016(self):
+        holidays = self.cal.holidays_set(2016)
+        self.assertIn(date(2016, 9, 19), holidays)
+        self.assertNotIn(date(2016, 5, 1), holidays)
+        self.assertNotIn(date(2016, 12, 26), holidays)
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 9, 18), holidays)
+        self.assertNotIn(date(2017, 5, 1), holidays)
+        self.assertNotIn(date(2017, 12, 26), holidays)
 
 
 class EstoniaTest(GenericCalendarTest):


### PR DESCRIPTION
Switzerland public holidays are canton-specific:

https://en.wikipedia.org/wiki/Public_holidays_in_Switzerland

Canton of Vaud doesn't have Labor day or boxing day, but has its own
"Lundi du Jeûne Fédéral" in september.

- [X] Tests with a significant number of years to be tested for your calendar.
- [X] Docstrings for the Calendar class and specific methods.
- [X] Calendar country / label added to the README.rst file,
- [X] Changelog amended with a mention like: "Added ``<country>`` by ``@pseudo`` (#)"