### PR TITLE
Adding Brazil states and cities, fixing major flaws in workalendar

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ master (unreleased)
 
 - Moved all the calendar of countries on the american continent in their own modules (#188).
 - Refactor base Calendar class get_weekend_days to use WEEKEND_DAYS more intelligently (#191 + #192).
+- Many corrections to the Brazil and various states / cities (#187).
 
 
 1.1.0 (2017-02-28)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ master (unreleased)
 - Refactor base Calendar class get_weekend_days to use WEEKEND_DAYS more intelligently (#191 + #192).
 - Many corrections to the Brazil and various states / cities (#187).
 - Added a ``good_friday_label`` class variable to ``ChristianMixin`` ; one can assign the right label to this holiday (#187).
+- Added a ``ash_wednesday_label`` class variable to ``ChristianMixin`` ; one can assign the right label to this holiday (#187).
 
 
 1.1.0 (2017-02-28)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@ master (unreleased)
 
 - Moved all the calendar of countries on the american continent in their own modules (#188).
 - Refactor base Calendar class get_weekend_days to use WEEKEND_DAYS more intelligently (#191 + #192).
-- Many corrections to the Brazil and various states / cities (#187).
+- Many additions to the Brazil and various states / cities. Were added: Acre, Alagoas, Amapá, Amazonas, Bahia, Ceará, Distrito Federal, Espírito Santo State, Goiás, Maranhão, Mato Grosso, Mato Grosso do Sul, Pará, Paraíba, Pernambuco, Piauí, Rio de Janeiro, Rio Grande do Norte, Rio Grande do Sul, Rondônia, Roraima, Santa Catarina, São Paulo, Sergipe, Tocantins, City of Vitória, City of Vila Velha, City of Cariacica, City of Guarapari and City of Serra (#187).
 - Added a ``good_friday_label`` class variable to ``ChristianMixin`` ; one can assign the right label to this holiday (#187).
 - Added a ``ash_wednesday_label`` class variable to ``ChristianMixin`` ; one can assign the right label to this holiday (#187).
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ master (unreleased)
 - Moved all the calendar of countries on the american continent in their own modules (#188).
 - Refactor base Calendar class get_weekend_days to use WEEKEND_DAYS more intelligently (#191 + #192).
 - Many corrections to the Brazil and various states / cities (#187).
+- Added a ``good_friday_label`` class variable to ``ChristianMixin`` ; one can assign the right label to this holiday (#187).
 
 
 1.1.0 (2017-02-28)

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -7,6 +7,7 @@ from .brazil import (
     BrazilBahia, BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto,
     BrazilGoias, BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul,
     BrazilPara, BrazilParaiba, BrazilPernambuco, BrazilPiaui,
+    BrazilRioDeJaneiro,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -33,6 +34,7 @@ __all__ = (
     BrazilParaiba,
     BrazilPernambuco,
     BrazilPiaui,
+    BrazilRioDeJaneiro,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -2,7 +2,9 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from .brazil import Brazil, BrazilAcre, BrazilSaoPauloState, BrazilSaoPauloCity
+from .brazil import (
+    Brazil, BrazilAcre, BrazilAlagoas, BrazilSaoPauloState, BrazilSaoPauloCity,
+)
 from .chile import Chile
 from .colombia import Colombia
 from .mexico import Mexico
@@ -12,6 +14,7 @@ from .panama import Panama
 __all__ = (
     Brazil,
     BrazilAcre,
+    BrazilAlagoas,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -7,7 +7,7 @@ from .brazil import (
     BrazilBahia, BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto,
     BrazilGoias, BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul,
     BrazilPara, BrazilParaiba, BrazilPernambuco, BrazilPiaui,
-    BrazilRioDeJaneiro,
+    BrazilRioDeJaneiro, BrazilRioGrandeDoNorte,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -35,6 +35,7 @@ __all__ = (
     BrazilPernambuco,
     BrazilPiaui,
     BrazilRioDeJaneiro,
+    BrazilRioGrandeDoNorte,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from .brazil import Brazil, BrazilSaoPauloState, BrazilSaoPauloCity
+from .brazil import Brazil, BrazilAcre, BrazilSaoPauloState, BrazilSaoPauloCity
 from .chile import Chile
 from .colombia import Colombia
 from .mexico import Mexico
@@ -11,6 +11,7 @@ from .panama import Panama
 
 __all__ = (
     Brazil,
+    BrazilAcre,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from .brazil import (
     Brazil, BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas,
+    BrazilBahia,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -18,6 +19,7 @@ __all__ = (
     BrazilAlagoas,
     BrazilAmapa,
     BrazilAmazonas,
+    BrazilBahia,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -6,7 +6,7 @@ from .brazil import (
     Brazil, BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas,
     BrazilBahia, BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto,
     BrazilGoias, BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul,
-    BrazilPara, BrazilParaiba, BrazilPernambuco,
+    BrazilPara, BrazilParaiba, BrazilPernambuco, BrazilPiaui,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -32,6 +32,7 @@ __all__ = (
     BrazilPara,
     BrazilParaiba,
     BrazilPernambuco,
+    BrazilPiaui,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -8,7 +8,7 @@ from .brazil import (
     BrazilGoias, BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul,
     BrazilPara, BrazilParaiba, BrazilPernambuco, BrazilPiaui,
     BrazilRioDeJaneiro, BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul,
-    BrazilRondonia, BrazilRoraima,
+    BrazilRondonia, BrazilRoraima, BrazilSantaCatarina,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -40,6 +40,7 @@ __all__ = (
     BrazilRioGrandeDoSul,
     BrazilRondonia,
     BrazilRoraima,
+    BrazilSantaCatarina,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -3,7 +3,8 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .brazil import (
-    Brazil, BrazilAcre, BrazilAlagoas, BrazilSaoPauloState, BrazilSaoPauloCity,
+    Brazil, BrazilAcre, BrazilAlagoas, BrazilAmapa,
+    BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
 from .colombia import Colombia
@@ -15,6 +16,7 @@ __all__ = (
     Brazil,
     BrazilAcre,
     BrazilAlagoas,
+    BrazilAmapa,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -10,7 +10,7 @@ from .brazil import (
     BrazilRioDeJaneiro, BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul,
     BrazilRondonia, BrazilRoraima, BrazilSantaCatarina, BrazilSaoPauloState,
     BrazilSaoPauloCity, BrazilSergipe, BrazilTocantins, BrazilVitoriaCity,
-    BrazilVilaVelhaCity, BrazilCariacicaCity,
+    BrazilVilaVelhaCity, BrazilCariacicaCity, BrazilGuarapariCity,
 )
 from .chile import Chile
 from .colombia import Colombia
@@ -49,6 +49,7 @@ __all__ = (
     BrazilVitoriaCity,
     BrazilVilaVelhaCity,
     BrazilCariacicaCity,
+    BrazilGuarapariCity,
     Chile,
     Colombia,
     Mexico,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from .brazil import (
     Brazil, BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas,
-    BrazilBahia,
+    BrazilBahia, BrazilCeara,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -20,6 +20,7 @@ __all__ = (
     BrazilAmapa,
     BrazilAmazonas,
     BrazilBahia,
+    BrazilCeara,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -11,6 +11,7 @@ from .brazil import (
     BrazilRondonia, BrazilRoraima, BrazilSantaCatarina, BrazilSaoPauloState,
     BrazilSaoPauloCity, BrazilSergipe, BrazilTocantins, BrazilVitoriaCity,
     BrazilVilaVelhaCity, BrazilCariacicaCity, BrazilGuarapariCity,
+    BrazilSerraCity,
 )
 from .chile import Chile
 from .colombia import Colombia
@@ -50,6 +51,7 @@ __all__ = (
     BrazilVilaVelhaCity,
     BrazilCariacicaCity,
     BrazilGuarapariCity,
+    BrazilSerraCity,
     Chile,
     Colombia,
     Mexico,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -5,6 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 from .brazil import (
     Brazil, BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas,
     BrazilBahia, BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto,
+    BrazilGoias,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -23,6 +24,7 @@ __all__ = (
     BrazilCeara,
     BrazilDistritoFederal,
     BrazilEspiritoSanto,
+    BrazilGoias,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -10,7 +10,7 @@ from .brazil import (
     BrazilRioDeJaneiro, BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul,
     BrazilRondonia, BrazilRoraima, BrazilSantaCatarina, BrazilSaoPauloState,
     BrazilSaoPauloCity, BrazilSergipe, BrazilTocantins, BrazilVitoriaCity,
-    BrazilVilaVelhaCity,
+    BrazilVilaVelhaCity, BrazilCariacicaCity,
 )
 from .chile import Chile
 from .colombia import Colombia
@@ -48,6 +48,7 @@ __all__ = (
     BrazilTocantins,
     BrazilVitoriaCity,
     BrazilVilaVelhaCity,
+    BrazilCariacicaCity,
     Chile,
     Colombia,
     Mexico,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -8,7 +8,7 @@ from .brazil import (
     BrazilGoias, BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul,
     BrazilPara, BrazilParaiba, BrazilPernambuco, BrazilPiaui,
     BrazilRioDeJaneiro, BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul,
-    BrazilRondonia,
+    BrazilRondonia, BrazilRoraima,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -39,6 +39,7 @@ __all__ = (
     BrazilRioGrandeDoNorte,
     BrazilRioGrandeDoSul,
     BrazilRondonia,
+    BrazilRoraima,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 from .brazil import (
     Brazil, BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas,
     BrazilBahia, BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto,
-    BrazilGoias,
+    BrazilGoias, BrazilMaranhao,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -25,6 +25,7 @@ __all__ = (
     BrazilDistritoFederal,
     BrazilEspiritoSanto,
     BrazilGoias,
+    BrazilMaranhao,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -10,6 +10,7 @@ from .brazil import (
     BrazilRioDeJaneiro, BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul,
     BrazilRondonia, BrazilRoraima, BrazilSantaCatarina, BrazilSaoPauloState,
     BrazilSaoPauloCity, BrazilSergipe, BrazilTocantins, BrazilVitoriaCity,
+    BrazilVilaVelhaCity,
 )
 from .chile import Chile
 from .colombia import Colombia
@@ -46,6 +47,7 @@ __all__ = (
     BrazilSergipe,
     BrazilTocantins,
     BrazilVitoriaCity,
+    BrazilVilaVelhaCity,
     Chile,
     Colombia,
     Mexico,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 from .brazil import (
     Brazil, BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas,
     BrazilBahia, BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto,
-    BrazilGoias, BrazilMaranhao, BrazilMatoGrosso,
+    BrazilGoias, BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -27,6 +27,7 @@ __all__ = (
     BrazilGoias,
     BrazilMaranhao,
     BrazilMatoGrosso,
+    BrazilMatoGrossoDoSul,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -9,7 +9,7 @@ from .brazil import (
     BrazilPara, BrazilParaiba, BrazilPernambuco, BrazilPiaui,
     BrazilRioDeJaneiro, BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul,
     BrazilRondonia, BrazilRoraima, BrazilSantaCatarina, BrazilSaoPauloState,
-    BrazilSaoPauloCity, BrazilSergipe,
+    BrazilSaoPauloCity, BrazilSergipe, BrazilTocantins,
 )
 from .chile import Chile
 from .colombia import Colombia
@@ -44,6 +44,7 @@ __all__ = (
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     BrazilSergipe,
+    BrazilTocantins,
     Chile,
     Colombia,
     Mexico,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -6,7 +6,7 @@ from .brazil import (
     Brazil, BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas,
     BrazilBahia, BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto,
     BrazilGoias, BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul,
-    BrazilPara, BrazilParaiba,
+    BrazilPara, BrazilParaiba, BrazilPernambuco,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -31,6 +31,7 @@ __all__ = (
     BrazilMatoGrossoDoSul,
     BrazilPara,
     BrazilParaiba,
+    BrazilPernambuco,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -6,7 +6,7 @@ from .brazil import (
     Brazil, BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas,
     BrazilBahia, BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto,
     BrazilGoias, BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul,
-    BrazilPara,
+    BrazilPara, BrazilParaiba,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -30,6 +30,7 @@ __all__ = (
     BrazilMatoGrosso,
     BrazilMatoGrossoDoSul,
     BrazilPara,
+    BrazilParaiba,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -6,6 +6,7 @@ from .brazil import (
     Brazil, BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas,
     BrazilBahia, BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto,
     BrazilGoias, BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul,
+    BrazilPara,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -28,6 +29,7 @@ __all__ = (
     BrazilMaranhao,
     BrazilMatoGrosso,
     BrazilMatoGrossoDoSul,
+    BrazilPara,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -7,7 +7,7 @@ from .brazil import (
     BrazilBahia, BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto,
     BrazilGoias, BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul,
     BrazilPara, BrazilParaiba, BrazilPernambuco, BrazilPiaui,
-    BrazilRioDeJaneiro, BrazilRioGrandeDoNorte,
+    BrazilRioDeJaneiro, BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -36,6 +36,7 @@ __all__ = (
     BrazilPiaui,
     BrazilRioDeJaneiro,
     BrazilRioGrandeDoNorte,
+    BrazilRioGrandeDoSul,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -8,8 +8,8 @@ from .brazil import (
     BrazilGoias, BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul,
     BrazilPara, BrazilParaiba, BrazilPernambuco, BrazilPiaui,
     BrazilRioDeJaneiro, BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul,
-    BrazilRondonia, BrazilRoraima, BrazilSantaCatarina,
-    BrazilSaoPauloState, BrazilSaoPauloCity,
+    BrazilRondonia, BrazilRoraima, BrazilSantaCatarina, BrazilSaoPauloState,
+    BrazilSaoPauloCity, BrazilSergipe,
 )
 from .chile import Chile
 from .colombia import Colombia
@@ -43,6 +43,7 @@ __all__ = (
     BrazilSantaCatarina,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
+    BrazilSergipe,
     Chile,
     Colombia,
     Mexico,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 from .brazil import (
     Brazil, BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas,
     BrazilBahia, BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto,
-    BrazilGoias, BrazilMaranhao,
+    BrazilGoias, BrazilMaranhao, BrazilMatoGrosso,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -26,6 +26,7 @@ __all__ = (
     BrazilEspiritoSanto,
     BrazilGoias,
     BrazilMaranhao,
+    BrazilMatoGrosso,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .brazil import (
-    Brazil, BrazilAcre, BrazilAlagoas, BrazilAmapa,
+    Brazil, BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -17,6 +17,7 @@ __all__ = (
     BrazilAcre,
     BrazilAlagoas,
     BrazilAmapa,
+    BrazilAmazonas,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from .brazil import (
     Brazil, BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas,
-    BrazilBahia, BrazilCeara, BrazilDistritoFederal,
+    BrazilBahia, BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -22,6 +22,7 @@ __all__ = (
     BrazilBahia,
     BrazilCeara,
     BrazilDistritoFederal,
+    BrazilEspiritoSanto,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from .brazil import (
     Brazil, BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas,
-    BrazilBahia, BrazilCeara,
+    BrazilBahia, BrazilCeara, BrazilDistritoFederal,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -21,6 +21,7 @@ __all__ = (
     BrazilAmazonas,
     BrazilBahia,
     BrazilCeara,
+    BrazilDistritoFederal,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -8,6 +8,7 @@ from .brazil import (
     BrazilGoias, BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul,
     BrazilPara, BrazilParaiba, BrazilPernambuco, BrazilPiaui,
     BrazilRioDeJaneiro, BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul,
+    BrazilRondonia,
     BrazilSaoPauloState, BrazilSaoPauloCity,
 )
 from .chile import Chile
@@ -37,6 +38,7 @@ __all__ = (
     BrazilRioDeJaneiro,
     BrazilRioGrandeDoNorte,
     BrazilRioGrandeDoSul,
+    BrazilRondonia,
     BrazilSaoPauloState,
     BrazilSaoPauloCity,
     Chile,

--- a/workalendar/america/__init__.py
+++ b/workalendar/america/__init__.py
@@ -9,7 +9,7 @@ from .brazil import (
     BrazilPara, BrazilParaiba, BrazilPernambuco, BrazilPiaui,
     BrazilRioDeJaneiro, BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul,
     BrazilRondonia, BrazilRoraima, BrazilSantaCatarina, BrazilSaoPauloState,
-    BrazilSaoPauloCity, BrazilSergipe, BrazilTocantins,
+    BrazilSaoPauloCity, BrazilSergipe, BrazilTocantins, BrazilVitoriaCity,
 )
 from .chile import Chile
 from .colombia import Colombia
@@ -45,6 +45,7 @@ __all__ = (
     BrazilSaoPauloCity,
     BrazilSergipe,
     BrazilTocantins,
+    BrazilVitoriaCity,
     Chile,
     Colombia,
     Mexico,

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -135,6 +135,14 @@ class BrazilPernambuco(Brazil):
     )
 
 
+class BrazilPiaui(Brazil):
+    "Brazil Piauí State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (3, 13, "Dia da Batalha do Jenipapo"),
+        (10, 19, "Dia do Piauí"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
 from datetime import timedelta
 
 from workalendar.core import WesternCalendar, ChristianMixin
@@ -250,3 +253,14 @@ class BrazilTocantins(Brazil):
         (9, 8, "Nossa Senhora da Natividade"),
         (10, 5, "Criação de Tocantins"),
     )
+
+
+class BrazilVitoriaCity(Brazil):
+    "Brazil Vitória City"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (4, 24, "Nossa Senhora da Penha"),  # Our Lady of Pain?
+        (9, 8, "Nossa Senhora da Vitória"),  # Our Lady of Vitória
+    )
+    include_corpus_christi = True
+    include_good_friday = True
+    good_friday_label = "Paixão do Cristo"

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -26,6 +26,16 @@ class BrazilAcre(Brazil):
     )
 
 
+class BrazilAlagoas(Brazil):
+    "Brazil Alagoas State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (6, 24, "São João"),
+        (6, 29, "São Pedro"),
+        (9, 16, "Emancipação política de Alagoas"),
+        (11, 20, "Consciência Negra")
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -265,3 +265,10 @@ class BrazilVitoriaCity(Brazil):
     include_corpus_christi = True
     include_good_friday = True
     good_friday_label = "Paixão do Cristo"
+
+
+class BrazilVilaVelhaCity(Brazil):
+    "Brazil Vila Velha City"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (5, 23, "Colonização do Solo Espírito-santense"),
+    )

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -184,6 +184,13 @@ class BrazilRioGrandeDoNorte(Brazil):
     )
 
 
+class BrazilRioGrandeDoSul(Brazil):
+    "Brazil Rio Grande do Sul State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (9, 20, "Revolução Farroupilha"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -92,6 +92,14 @@ class BrazilGoias(Brazil):
     )
 
 
+class BrazilMaranhao(Brazil):
+    "Brazil Maranhão State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (7, 28, "Adesão do Maranhão á independência do Brasil"),
+        (12, 8, "Dia de Nossa Senhora da Conceição"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -206,6 +206,13 @@ class BrazilRoraima(Brazil):
     )
 
 
+class BrazilSantaCatarina(Brazil):
+    "Brazil Santa Catarina State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (8, 11, "Criação da capitania, separando-se de SP"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -100,6 +100,13 @@ class BrazilMaranhao(Brazil):
     )
 
 
+class BrazilMatoGrosso(Brazil):
+    "Brazil Mato Grosso State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (11, 29, "Consciência Negra"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 
 from workalendar.core import WesternCalendar, ChristianMixin
+from workalendar.core import MON
 
 
 class Brazil(WesternCalendar, ChristianMixin):
@@ -14,6 +15,14 @@ class Brazil(WesternCalendar, ChristianMixin):
         (11, 2, "All Souls' Day"),
         (11, 15, "Republic Day"),
     )
+
+    def get_carnaval(self, year):
+        """
+        Return the third day of Carnaval (Tuesday)
+
+        This day is shared holidays by several Brazil states.
+        """
+        return self.get_easter_sunday(year) - timedelta(days=47)
 
 
 class BrazilAcre(Brazil):
@@ -143,6 +152,30 @@ class BrazilPiaui(Brazil):
     )
 
 
+class BrazilRioDeJaneiro(Brazil):
+    "Brazil Rio de Janeiro State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (4, 23, "Dia de São Jorge"),
+        (10, 28, "Dia do Funcionário Público"),
+        (11, 20, "Dia da Consciência Negra"),
+        (12, 8, "Dia de Nossa Senhora da Conceição"),
+    )
+
+    def get_dia_do_comercio(self, year):
+        """
+        Return Dia do Comércio variable date
+
+        It happens on the 3rd Monday of october.
+        """
+        return BrazilRioDeJaneiro.get_nth_weekday_in_month(year, 10, MON, 3)
+
+    def get_variable_days(self, year):
+        days = super(BrazilRioDeJaneiro, self).get_variable_days(year)
+        days.append((self.get_carnaval(year), "Carnaval"))
+        days.append((self.get_dia_do_comercio(year), "Dia do Comércio"))
+        return days
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
@@ -158,9 +191,6 @@ class BrazilSaoPauloCity(BrazilSaoPauloState):
     )
     include_easter_sunday = True
     include_corpus_christi = True
-
-    def get_carnaval(self, year):
-        return self.get_easter_sunday(year) - timedelta(days=47)
 
     def get_variable_days(self, year):
         days = super(BrazilSaoPauloCity, self).get_variable_days(year)

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -241,3 +241,12 @@ class BrazilSergipe(Brazil):
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
         (7, 8, "Autonomia política de Sergipe"),
     )
+
+
+class BrazilTocantins(Brazil):
+    "Brazil Tocantins State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (1, 1, "Instalação de Tocantins"),
+        (9, 8, "Nossa Senhora da Natividade"),
+        (10, 5, "Criação de Tocantins"),
+    )

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -55,6 +55,13 @@ class BrazilAmazonas(Brazil):
     )
 
 
+class BrazilBahia(Brazil):
+    "Brazil Bahia State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (7, 2, "Independência da Bahia"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -114,6 +114,13 @@ class BrazilMatoGrossoDoSul(Brazil):
     )
 
 
+class BrazilPara(Brazil):
+    "Brazil Pará State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (8, 15, "Adesão do Grão-Pará á independência do Brasil"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -62,6 +62,14 @@ class BrazilBahia(Brazil):
     )
 
 
+class BrazilCeara(Brazil):
+    "Brazil Ceará State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (3, 19, "São José"),
+        (3, 23, "Data Manga do Ceará")
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -191,6 +191,14 @@ class BrazilRioGrandeDoSul(Brazil):
     )
 
 
+class BrazilRondonia(Brazil):
+    "Brazil Rondônia State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (1, 4, "Criação do estado"),
+        (6, 18, "Dia do Evangélico"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -36,6 +36,16 @@ class BrazilAlagoas(Brazil):
     )
 
 
+class BrazilAmapa(Brazil):
+    "Brazil Amapá State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (3, 19, "Dia de São José"),
+        (7, 25, "São Tiago"),
+        (10, 5, "Criação do estado"),
+        (11, 20, "Consciência Negra"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -234,3 +234,10 @@ class BrazilSaoPauloCity(BrazilSaoPauloState):
         days.append((self.get_carnaval(year), "Carnaval"))
         days.append((self.get_good_friday(year), "Sexta-feira da Paixão"))
         return days
+
+
+class BrazilSergipe(Brazil):
+    "Brazil Sergipe State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (7, 8, "Autonomia política de Sergipe"),
+    )

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -293,3 +293,23 @@ class BrazilGuarapariCity(Brazil):
         (11, 29, "Consciência Negra"),
         (12, 8, "Nossa Senhora Conceição"),
     )
+
+
+class BrazilSerraCity(Brazil):
+    "Brazil Serra City"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (6, 29, "São Pedro"),
+        (12, 8, "Nossa Senhora Conceição"),
+        (12, 26, "Dia do Serrano"),
+    )
+    include_ash_wednesday = True
+    ash_wednesday_label = "Quarta-feira de cinzas"
+    include_good_friday = True
+    good_friday_label = "Paixão do Cristo"
+
+    def get_variable_days(self, year):
+        days = super(BrazilSerraCity, self).get_variable_days(year)
+        carnaval_tuesday = self.get_carnaval(year)
+        days.append((carnaval_tuesday - timedelta(days=1), "Carnaval Monday"))
+        days.append((carnaval_tuesday, "Carnaval"))
+        return days

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -128,6 +128,13 @@ class BrazilParaiba(Brazil):
     )
 
 
+class BrazilPernambuco(Brazil):
+    "Brazil Pernambuco State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (6, 24, "São João"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from datetime import timedelta
+from datetime import timedelta, date
 
 from workalendar.core import WesternCalendar, ChristianMixin
 from workalendar.core import MON
@@ -18,6 +18,21 @@ class Brazil(WesternCalendar, ChristianMixin):
         (11, 2, "All Souls' Day"),
         (11, 15, "Republic Day"),
     )
+    include_sao_jose = False
+    sao_jose_label = "São José"
+    include_sao_pedro = False
+    sao_pedro_label = "São Pedro"
+    include_sao_joao = False
+    sao_joao_label = "São João"
+    include_servidor_publico = False
+    servidor_publico_label = "Dia do Servidor Público"
+    # Consciência Negra day
+    include_consciencia_negra = False
+    # There are two dates for the Consciência Negra day
+    # The most common is November, 20th
+    consciencia_negra_day = (11, 20)
+    consciencia_negra_label = "Consciência Negra"
+    include_nossa_senhora_conceicao = False
 
     def get_carnaval(self, year):
         """
@@ -26,6 +41,27 @@ class Brazil(WesternCalendar, ChristianMixin):
         This day is shared holidays by several Brazil states.
         """
         return self.get_easter_sunday(year) - timedelta(days=47)
+
+    def get_variable_days(self, year):
+        days = super(Brazil, self).get_variable_days(year)
+        if self.include_sao_jose:
+            days.append((date(year, 3, 19), self.sao_jose_label))
+        if self.include_sao_pedro:
+            days.append((date(year, 6, 29), self.sao_pedro_label))
+        if self.include_sao_joao:
+            days.append((date(year, 6, 24), self.sao_joao_label))
+        if self.include_servidor_publico:
+            days.append((date(year, 10, 28), self.servidor_publico_label))
+        if self.include_consciencia_negra:
+            month, day = self.consciencia_negra_day
+            days.append(
+                (date(year, month, day), self.consciencia_negra_label)
+            )
+        if self.include_nossa_senhora_conceicao:
+            days.append(
+                (date(year, 12, 8), "Dia de Nossa Senhora da Conceição")
+            )
+        return days
 
 
 class BrazilAcre(Brazil):
@@ -41,30 +77,31 @@ class BrazilAcre(Brazil):
 class BrazilAlagoas(Brazil):
     "Brazil Alagoas State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
-        (6, 24, "São João"),
-        (6, 29, "São Pedro"),
         (9, 16, "Emancipação política de Alagoas"),
-        (11, 20, "Consciência Negra")
     )
+    include_sao_pedro = True
+    include_sao_joao = True
+    include_consciencia_negra = True
 
 
 class BrazilAmapa(Brazil):
     "Brazil Amapá State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
-        (3, 19, "Dia de São José"),
         (7, 25, "São Tiago"),
         (10, 5, "Criação do estado"),
-        (11, 20, "Consciência Negra"),
     )
+    include_sao_jose = True
+    sao_jose_label = "Dia de São José"
+    include_consciencia_negra = True
 
 
 class BrazilAmazonas(Brazil):
     "Brazil Amazonas State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
         (9, 5, "Elevação do Amazonas á categoria de província"),
-        (11, 20, "Consciência Negra"),
-        (12, 8, "Dia de Nossa Senhora da Conceição"),
     )
+    include_consciencia_negra = True
+    include_nossa_senhora_conceicao = True
 
 
 class BrazilBahia(Brazil):
@@ -77,9 +114,9 @@ class BrazilBahia(Brazil):
 class BrazilCeara(Brazil):
     "Brazil Ceará State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
-        (3, 19, "São José"),
-        (3, 23, "Data Manga do Ceará")
+        (3, 23, "Data Manga do Ceará"),
     )
+    include_sao_jose = True
 
 
 class BrazilDistritoFederal(Brazil):
@@ -92,31 +129,26 @@ class BrazilDistritoFederal(Brazil):
 
 class BrazilEspiritoSanto(Brazil):
     "Brazil Espírito Santo State"
-    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
-        (10, 28, "Dia do Servidor Público"),
-    )
+    include_servidor_publico = True
 
 
 class BrazilGoias(Brazil):
     "Brazil Goiás State"
-    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
-        (10, 28, "Dia do Servidor Público"),
-    )
+    include_servidor_publico = True
 
 
 class BrazilMaranhao(Brazil):
     "Brazil Maranhão State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
         (7, 28, "Adesão do Maranhão á independência do Brasil"),
-        (12, 8, "Dia de Nossa Senhora da Conceição"),
     )
+    include_nossa_senhora_conceicao = True
 
 
 class BrazilMatoGrosso(Brazil):
     "Brazil Mato Grosso State"
-    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
-        (11, 29, "Consciência Negra"),
-    )
+    include_consciencia_negra = True
+    consciencia_negra_day = (11, 29)
 
 
 class BrazilMatoGrossoDoSul(Brazil):
@@ -142,9 +174,7 @@ class BrazilParaiba(Brazil):
 
 class BrazilPernambuco(Brazil):
     "Brazil Pernambuco State"
-    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
-        (6, 24, "São João"),
-    )
+    include_sao_joao = True
 
 
 class BrazilPiaui(Brazil):
@@ -159,10 +189,12 @@ class BrazilRioDeJaneiro(Brazil):
     "Brazil Rio de Janeiro State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
         (4, 23, "Dia de São Jorge"),
-        (10, 28, "Dia do Funcionário Público"),
-        (11, 20, "Dia da Consciência Negra"),
-        (12, 8, "Dia de Nossa Senhora da Conceição"),
     )
+    include_servidor_publico = True
+    servidor_publico_label = "Dia do Funcionário Público"
+    include_consciencia_negra = True
+    consciencia_negra_label = "Dia da Consciência Negra"
+    include_nossa_senhora_conceicao = True
 
     def get_dia_do_comercio(self, year):
         """
@@ -182,9 +214,10 @@ class BrazilRioDeJaneiro(Brazil):
 class BrazilRioGrandeDoNorte(Brazil):
     "Brazil Rio Grande do Norte State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
-        (6, 29, "Dua de São Pedro"),
         (10, 3, "Mártires de Cunhaú e Uruaçuu"),
     )
+    include_sao_pedro = True
+    sao_pedro_label = "Dua de São Pedro"
 
 
 class BrazilRioGrandeDoSul(Brazil):
@@ -227,12 +260,13 @@ class BrazilSaoPauloCity(BrazilSaoPauloState):
     "Brazil São Paulo City"
     FIXED_HOLIDAYS = BrazilSaoPauloState.FIXED_HOLIDAYS + (
         (1, 25, "Anniversary of the city of São Paulo"),
-        (11, 20, "Dia da Consciência Negra")
     )
     include_easter_sunday = True
     include_corpus_christi = True
     include_good_friday = True
     good_friday_label = "Sexta-feira da Paixão"
+    include_consciencia_negra = True
+    consciencia_negra_label = "Dia da Consciência Negra"
 
     def get_variable_days(self, year):
         days = super(BrazilSaoPauloCity, self).get_variable_days(year)
@@ -278,34 +312,36 @@ class BrazilCariacicaCity(Brazil):
     "Brazil Cariacica City"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
         (4, 13, "Nossa Senhora da Penha"),
-        (6, 24, "São João Batista / Aniversãrio de Cariacica"),
     )
     include_corpus_christi = True
     include_good_friday = True
     good_friday_label = "Paixão do Cristo"
+    include_sao_joao = True
+    sao_joao_label = "São João Batista / Aniversãrio de Cariacica"
 
 
 class BrazilGuarapariCity(Brazil):
     "Brazil Guarapari City"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
-        (6, 29, "São Pedro"),
         (9, 19, "Emancipação de Guarapari"),
-        (11, 29, "Consciência Negra"),
-        (12, 8, "Nossa Senhora Conceição"),
     )
+    include_sao_pedro = True
+    include_consciencia_negra = True
+    consciencia_negra_day = (11, 29)
+    include_nossa_senhora_conceicao = True
 
 
 class BrazilSerraCity(Brazil):
     "Brazil Serra City"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
-        (6, 29, "São Pedro"),
-        (12, 8, "Nossa Senhora Conceição"),
         (12, 26, "Dia do Serrano"),
     )
     include_ash_wednesday = True
     ash_wednesday_label = "Quarta-feira de cinzas"
     include_good_friday = True
     good_friday_label = "Paixão do Cristo"
+    include_sao_pedro = True
+    include_nossa_senhora_conceicao = True
 
     def get_variable_days(self, year):
         days = super(BrazilSerraCity, self).get_variable_days(year)

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -121,6 +121,13 @@ class BrazilPara(Brazil):
     )
 
 
+class BrazilParaiba(Brazil):
+    "Brazil Paraíba State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (8, 5, "Fundação do Estado"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -283,3 +283,13 @@ class BrazilCariacicaCity(Brazil):
     include_corpus_christi = True
     include_good_friday = True
     good_friday_label = "Paixão do Cristo"
+
+
+class BrazilGuarapariCity(Brazil):
+    "Brazil Guarapari City"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (6, 29, "São Pedro"),
+        (9, 19, "Emancipação de Guarapari"),
+        (11, 29, "Consciência Negra"),
+        (12, 8, "Nossa Senhora Conceição"),
+    )

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -231,11 +231,12 @@ class BrazilSaoPauloCity(BrazilSaoPauloState):
     )
     include_easter_sunday = True
     include_corpus_christi = True
+    include_good_friday = True
+    good_friday_label = "Sexta-feira da Paixão"
 
     def get_variable_days(self, year):
         days = super(BrazilSaoPauloCity, self).get_variable_days(year)
         days.append((self.get_carnaval(year), "Carnaval"))
-        days.append((self.get_good_friday(year), "Sexta-feira da Paixão"))
         return days
 
 

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -85,6 +85,13 @@ class BrazilEspiritoSanto(Brazil):
     )
 
 
+class BrazilGoias(Brazil):
+    "Brazil Goiás State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (10, 28, "Dia do Servidor Público"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -199,6 +199,13 @@ class BrazilRondonia(Brazil):
     )
 
 
+class BrazilRoraima(Brazil):
+    "Brazil Roraima State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (10, 5, "Criação de Roraima"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -176,6 +176,14 @@ class BrazilRioDeJaneiro(Brazil):
         return days
 
 
+class BrazilRioGrandeDoNorte(Brazil):
+    "Brazil Rio Grande do Norte State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (6, 29, "Dua de São Pedro"),
+        (10, 3, "Mártires de Cunhaú e Uruaçuu"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -272,3 +272,14 @@ class BrazilVilaVelhaCity(Brazil):
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
         (5, 23, "Colonização do Solo Espírito-santense"),
     )
+
+
+class BrazilCariacicaCity(Brazil):
+    "Brazil Cariacica City"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (4, 13, "Nossa Senhora da Penha"),
+        (6, 24, "São João Batista / Aniversãrio de Cariacica"),
+    )
+    include_corpus_christi = True
+    include_good_friday = True
+    good_friday_label = "Paixão do Cristo"

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -46,6 +46,15 @@ class BrazilAmapa(Brazil):
     )
 
 
+class BrazilAmazonas(Brazil):
+    "Brazil Amazonas State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (9, 5, "Elevação do Amazonas á categoria de província"),
+        (11, 20, "Consciência Negra"),
+        (12, 8, "Dia de Nossa Senhora da Conceição"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -78,6 +78,13 @@ class BrazilDistritoFederal(Brazil):
     )
 
 
+class BrazilEspiritoSanto(Brazil):
+    "Brazil Espírito Santo State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (10, 28, "Dia do Servidor Público"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -70,6 +70,14 @@ class BrazilCeara(Brazil):
     )
 
 
+class BrazilDistritoFederal(Brazil):
+    "Brazil Distrito Federal State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (4, 21, "Fundação de Brasília"),
+        (11, 30, "Dia do Evangélico"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -107,6 +107,13 @@ class BrazilMatoGrosso(Brazil):
     )
 
 
+class BrazilMatoGrossoDoSul(Brazil):
+    "Brazil Mato Grosso do Sul State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (10, 11, "Criação do estado"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -16,6 +16,16 @@ class Brazil(WesternCalendar, ChristianMixin):
     )
 
 
+class BrazilAcre(Brazil):
+    "Brazil Acre State"
+    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+        (1, 23, "Dia do evangélico"),
+        (6, 15, "Aniversário do Acre"),
+        (9, 5, "Dia da Amazônia"),
+        (11, 17, "Assinatura do Tratado de Petrópolis"),
+    )
+
+
 class BrazilSaoPauloState(Brazil):
     "Brazil São Paulo State"
     FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -1,4 +1,6 @@
-"""Working day tools
+# -*- coding: utf-8 -*-
+"""
+Working day tools
 """
 import warnings
 from calendar import monthrange
@@ -253,6 +255,7 @@ class ChristianMixin(Calendar):
     include_palm_sunday = False
     include_holy_thursday = False
     include_good_friday = False
+    good_friday_label = "Good Friday"
     include_easter_monday = False
     include_easter_saturday = False
     include_easter_sunday = False
@@ -338,7 +341,7 @@ class ChristianMixin(Calendar):
         if self.include_holy_thursday:
             days.append((self.get_holy_thursday(year), "Holy Thursday"))
         if self.include_good_friday:
-            days.append((self.get_good_friday(year), "Good Friday"))
+            days.append((self.get_good_friday(year), self.good_friday_label))
         if self.include_easter_saturday:
             days.append((self.get_easter_saturday(year), "Easter Saturday"))
         if self.include_easter_sunday:

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -252,6 +252,7 @@ class ChristianMixin(Calendar):
     include_clean_monday = False
     include_annunciation = False
     include_ash_wednesday = False
+    ash_wednesday_label = "Ash Wednesday"
     include_palm_sunday = False
     include_holy_thursday = False
     include_good_friday = False
@@ -335,7 +336,9 @@ class ChristianMixin(Calendar):
         if self.include_annunciation:
             days.append((date(year, 3, 25), "Annunciation"))
         if self.include_ash_wednesday:
-            days.append((self.get_ash_wednesday(year), "Ash Wednesday"))
+            days.append(
+                (self.get_ash_wednesday(year), self.ash_wednesday_label)
+            )
         if self.include_palm_sunday:
             days.append((self.get_palm_sunday(year), "Palm Sunday"))
         if self.include_holy_thursday:

--- a/workalendar/tests/test_america.py
+++ b/workalendar/tests/test_america.py
@@ -1,48 +1,8 @@
 # -*- coding: utf-8 -*-
 from datetime import date
 from workalendar.tests import GenericCalendarTest
-from workalendar.america import Brazil, BrazilSaoPauloState
-from workalendar.america import BrazilSaoPauloCity
 from workalendar.america import Colombia
 from workalendar.america import Mexico, Chile, Panama
-
-
-class BrazilTest(GenericCalendarTest):
-    cal_class = Brazil
-
-    def test_year_2013(self):
-        holidays = self.cal.holidays_set(2013)
-        self.assertIn(date(2013, 1, 1), holidays)  # new year
-        self.assertIn(date(2013, 4, 21), holidays)  # Tiradentes
-        self.assertIn(date(2013, 5, 1), holidays)  # Dia do trabalhador
-        self.assertIn(date(2013, 9, 7), holidays)  # Dia da Independência
-        self.assertIn(date(2013, 10, 12), holidays)  # Nossa Senhora Aparecida
-        self.assertIn(date(2013, 11, 2), holidays)  # Finados
-        self.assertIn(date(2013, 11, 15), holidays)  # Proclamação da República
-        self.assertIn(date(2013, 12, 25), holidays)  # Natal
-
-
-class SaoPauloStateTest(BrazilTest):
-    cal_class = BrazilSaoPauloState
-
-    def test_regional_2013(self):
-        holidays = self.cal.holidays_set(2013)
-        # Revolução Constitucionalista de 1932
-        self.assertIn(date(2013, 7, 9), holidays)
-
-
-class SaoPauloCityTest(SaoPauloStateTest):
-    cal_class = BrazilSaoPauloCity
-
-    def test_city_2013(self):
-        holidays = self.cal.holidays_set(2013)
-        # Aniversário da Cidade de São Paulo
-        self.assertIn(date(2013, 1, 25), holidays)
-        self.assertIn(date(2013, 2, 12), holidays)  # Carnaval
-        self.assertIn(date(2013, 11, 20), holidays)  # Dia da Consciência Negra
-        self.assertIn(date(2013, 3, 29), holidays)  # Sexta-feira da Paixão
-        self.assertIn(date(2013, 3, 31), holidays)  # Páscoa
-        self.assertIn(date(2013, 5, 30), holidays)  # Corpus Christi
 
 
 class ChileTest(GenericCalendarTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -6,7 +6,7 @@ from datetime import date
 from workalendar.tests import GenericCalendarTest
 from workalendar.america import (
     Brazil, BrazilSaoPauloState, BrazilSaoPauloCity,
-    BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas
+    BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas, BrazilBahia,
 )
 
 
@@ -70,6 +70,14 @@ class BrazilAmazonasTest(BrazilTest):
         self.assertIn(date(2017, 11, 20), holidays)  # Consciência Negra
         # Dia de Nossa Senhora da Conceição
         self.assertIn(date(2017, 12, 8), holidays)
+
+
+class BrazilBahiaTest(BrazilTest):
+    cal_class = BrazilBahia
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 7, 2), holidays)  # Independência da Bahia
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -11,6 +11,7 @@ from workalendar.america import (
     BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul, BrazilPara,
     BrazilParaiba, BrazilPernambuco, BrazilPiaui, BrazilRioDeJaneiro,
     BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul, BrazilRondonia,
+    BrazilRoraima,
 )
 
 
@@ -220,6 +221,14 @@ class BrazilRondoniaTest(BrazilTest):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 1, 4), holidays)  # Criação do estado
         self.assertIn(date(2017, 6, 18), holidays)  # Dia do Evangélico
+
+
+class BrazilRoraimaTest(BrazilTest):
+    cal_class = BrazilRoraima
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 10, 5), holidays)  # Criação de Roraima
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -13,7 +13,7 @@ from workalendar.america import (
     BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul, BrazilRondonia,
     BrazilRoraima, BrazilSantaCatarina, BrazilSergipe, BrazilTocantins,
     # Cities
-    BrazilSaoPauloCity, BrazilVitoriaCity,
+    BrazilSaoPauloCity, BrazilVitoriaCity, BrazilVilaVelhaCity,
 )
 
 
@@ -314,3 +314,12 @@ class BrazilVitoriaCityTest(BrazilTest):
             self.cal.get_holiday_label(good_friday),
             "Paixão do Cristo",
         )
+
+
+class BrazilVilaVelhaCityTest(BrazilTest):
+    cal_class = BrazilVilaVelhaCity
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        # Colonização do Solo Espírito-santense
+        self.assertIn(date(2017, 5, 23), holidays)

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -14,6 +14,7 @@ from workalendar.america import (
     BrazilRoraima, BrazilSantaCatarina, BrazilSergipe, BrazilTocantins,
     # Cities
     BrazilSaoPauloCity, BrazilVitoriaCity, BrazilVilaVelhaCity,
+    BrazilCariacicaCity,
 )
 
 
@@ -323,3 +324,27 @@ class BrazilVilaVelhaCityTest(BrazilTest):
         holidays = self.cal.holidays_set(2017)
         # Colonização do Solo Espírito-santense
         self.assertIn(date(2017, 5, 23), holidays)
+
+
+class BrazilCariacicaCityTest(BrazilTest):
+    cal_class = BrazilCariacicaCity
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        # Fixed days
+        self.assertIn(date(2017, 4, 13), holidays)  # Nossa Senhora da Penha
+        # São João Batista / Aniversãrio de Cariacica
+        self.assertIn(date(2017, 6, 24), holidays)
+
+        # Variable days: Corpus Christie
+        corpus_christie = date(2017, 6, 15)
+        self.assertIn(corpus_christie, holidays)
+
+        # Variable days: Good friday
+        good_friday = date(2017, 4, 14)
+        self.assertIn(good_friday, holidays)
+        # Test label
+        self.assertEqual(
+            self.cal.get_holiday_label(good_friday),
+            "Paixão do Cristo",
+        )

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from datetime import date
+from workalendar.tests import GenericCalendarTest
+from workalendar.america import (
+    Brazil, BrazilSaoPauloState, BrazilSaoPauloCity
+)
+
+
+class BrazilTest(GenericCalendarTest):
+    cal_class = Brazil
+
+    def test_year_2013(self):
+        holidays = self.cal.holidays_set(2013)
+        self.assertIn(date(2013, 1, 1), holidays)  # new year
+        self.assertIn(date(2013, 4, 21), holidays)  # Tiradentes
+        self.assertIn(date(2013, 5, 1), holidays)  # Dia do trabalhador
+        self.assertIn(date(2013, 9, 7), holidays)  # Dia da Independência
+        self.assertIn(date(2013, 10, 12), holidays)  # Nossa Senhora Aparecida
+        self.assertIn(date(2013, 11, 2), holidays)  # Finados
+        self.assertIn(date(2013, 11, 15), holidays)  # Proclamação da República
+        self.assertIn(date(2013, 12, 25), holidays)  # Natal
+
+
+class SaoPauloStateTest(BrazilTest):
+    cal_class = BrazilSaoPauloState
+
+    def test_regional_2013(self):
+        holidays = self.cal.holidays_set(2013)
+        # Revolução Constitucionalista de 1932
+        self.assertIn(date(2013, 7, 9), holidays)
+
+
+class SaoPauloCityTest(SaoPauloStateTest):
+    cal_class = BrazilSaoPauloCity
+
+    def test_city_2013(self):
+        holidays = self.cal.holidays_set(2013)
+        # Aniversário da Cidade de São Paulo
+        self.assertIn(date(2013, 1, 25), holidays)
+        self.assertIn(date(2013, 2, 12), holidays)  # Carnaval
+        self.assertIn(date(2013, 11, 20), holidays)  # Dia da Consciência Negra
+        self.assertIn(date(2013, 3, 29), holidays)  # Sexta-feira da Paixão
+        self.assertIn(date(2013, 3, 31), holidays)  # Páscoa
+        self.assertIn(date(2013, 5, 30), holidays)  # Corpus Christi

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -8,7 +8,7 @@ from workalendar.america import (
     Brazil, BrazilSaoPauloState, BrazilSaoPauloCity,
     BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas, BrazilBahia,
     BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto, BrazilGoias,
-    BrazilMaranhao, BrazilMatoGrosso,
+    BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul,
 )
 
 
@@ -133,6 +133,14 @@ class BrazilMatoGrossoTest(BrazilTest):
     def test_year_2017(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 11, 29), holidays)  # Consciência Negra
+
+
+class BrazilMatoGrossoDoSulTest(BrazilTest):
+    cal_class = BrazilMatoGrossoDoSul
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 10, 11), holidays)  # Criação do estado
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -5,13 +5,15 @@ from __future__ import (absolute_import, division, print_function,
 from datetime import date
 from workalendar.tests import GenericCalendarTest
 from workalendar.america import (
-    Brazil, BrazilSaoPauloState, BrazilSaoPauloCity,
+    Brazil, BrazilSaoPauloState,
     BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas, BrazilBahia,
     BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto, BrazilGoias,
     BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul, BrazilPara,
     BrazilParaiba, BrazilPernambuco, BrazilPiaui, BrazilRioDeJaneiro,
     BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul, BrazilRondonia,
     BrazilRoraima, BrazilSantaCatarina, BrazilSergipe, BrazilTocantins,
+    # Cities
+    BrazilSaoPauloCity, BrazilVitoriaCity,
 )
 
 
@@ -281,3 +283,26 @@ class BrazilTocantinsTest(BrazilTest):
         # Nossa Senhora da Natividade
         self.assertIn(date(2017, 9, 8), holidays)
         self.assertIn(date(2017, 10, 5), holidays)  # Criação de Tocantins
+
+
+class BrazilVitoriaCityTest(BrazilTest):
+    cal_class = BrazilVitoriaCity
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        # Fixed days
+        self.assertIn(date(2017, 4, 24), holidays)  # Nossa Senhora da Penha
+        self.assertIn(date(2017, 9, 8), holidays)  # Nossa Senhora da Vitória
+
+        # Variable days: Corpus Christie
+        corpus_christie = date(2017, 6, 15)
+        self.assertIn(corpus_christie, holidays)
+
+        # Variable days: Good friday
+        good_friday = date(2017, 4, 14)
+        self.assertIn(good_friday, holidays)
+        # Test label
+        self.assertEqual(
+            self.cal.get_holiday_label(good_friday),
+            "Paixão do Cristo",
+        )

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -8,6 +8,7 @@ from workalendar.america import (
     Brazil, BrazilSaoPauloState, BrazilSaoPauloCity,
     BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas, BrazilBahia,
     BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto, BrazilGoias,
+    BrazilMaranhao,
 )
 
 
@@ -113,6 +114,17 @@ class BrazilGoiasTest(BrazilTest):
     def test_year_2017(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 10, 28), holidays)  # Dia do Servidor Público
+
+
+class BrazilMaranhaoTest(BrazilTest):
+    cal_class = BrazilMaranhao
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        # Adesão do Maranhão á independência do Brasil
+        self.assertIn(date(2017, 7, 28), holidays)
+        # Dia de Nossa Senhora da Conceição
+        self.assertIn(date(2017, 12, 8), holidays)
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -9,7 +9,7 @@ from workalendar.america import (
     BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas, BrazilBahia,
     BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto, BrazilGoias,
     BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul, BrazilPara,
-    BrazilParaiba, BrazilPernambuco,
+    BrazilParaiba, BrazilPernambuco, BrazilPiaui,
 )
 
 
@@ -167,6 +167,16 @@ class BrazilPernambucoTest(BrazilTest):
     def test_year_2017(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 6, 24), holidays)  # São João
+
+
+class BrazilPiauiTest(BrazilTest):
+    cal_class = BrazilPiaui
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        # Dia da Batalha do Jenipapo
+        self.assertIn(date(2017, 3, 13), holidays)
+        self.assertIn(date(2017, 10, 19), holidays)  # Dia do Piauí
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -5,7 +5,8 @@ from __future__ import (absolute_import, division, print_function,
 from datetime import date
 from workalendar.tests import GenericCalendarTest
 from workalendar.america import (
-    Brazil, BrazilSaoPauloState, BrazilSaoPauloCity
+    Brazil, BrazilSaoPauloState, BrazilSaoPauloCity,
+    BrazilAcre
 )
 
 
@@ -22,6 +23,18 @@ class BrazilTest(GenericCalendarTest):
         self.assertIn(date(2013, 11, 2), holidays)  # Finados
         self.assertIn(date(2013, 11, 15), holidays)  # Proclamação da República
         self.assertIn(date(2013, 12, 25), holidays)  # Natal
+
+
+class BrazilAcreTest(BrazilTest):
+    cal_class = BrazilAcre
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 1, 23), holidays)  # Dia do evangélico
+        self.assertIn(date(2017, 6, 15), holidays)  # niversário do Acre
+        self.assertIn(date(2017, 9, 5), holidays)  # Dia da Amazônia
+        # Assinatura do Tratado de Petrópolis
+        self.assertIn(date(2017, 11, 17), holidays)
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -11,7 +11,7 @@ from workalendar.america import (
     BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul, BrazilPara,
     BrazilParaiba, BrazilPernambuco, BrazilPiaui, BrazilRioDeJaneiro,
     BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul, BrazilRondonia,
-    BrazilRoraima, BrazilSantaCatarina,
+    BrazilRoraima, BrazilSantaCatarina, BrazilSergipe,
 )
 
 
@@ -261,3 +261,12 @@ class SaoPauloCityTest(SaoPauloStateTest):
         self.assertIn(date(2013, 3, 29), holidays)  # Sexta-feira da Paixão
         self.assertIn(date(2013, 3, 31), holidays)  # Páscoa
         self.assertIn(date(2013, 5, 30), holidays)  # Corpus Christi
+
+
+class BrazilSergipeTest(BrazilTest):
+    cal_class = BrazilSergipe
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        # Autonomia política de Sergipe
+        self.assertIn(date(2017, 7, 8), holidays)

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -10,7 +10,7 @@ from workalendar.america import (
     BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto, BrazilGoias,
     BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul, BrazilPara,
     BrazilParaiba, BrazilPernambuco, BrazilPiaui, BrazilRioDeJaneiro,
-    BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul,
+    BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul, BrazilRondonia,
 )
 
 
@@ -211,6 +211,15 @@ class BrazilRioGrandeDoSulTest(BrazilTest):
     def test_year_2017(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 9, 20), holidays)  # Revolução Farroupilha
+
+
+class BrazilRondoniaTest(BrazilTest):
+    cal_class = BrazilRondonia
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 1, 4), holidays)  # Criação do estado
+        self.assertIn(date(2017, 6, 18), holidays)  # Dia do Evangélico
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -6,7 +6,7 @@ from datetime import date
 from workalendar.tests import GenericCalendarTest
 from workalendar.america import (
     Brazil, BrazilSaoPauloState, BrazilSaoPauloCity,
-    BrazilAcre, BrazilAlagoas
+    BrazilAcre, BrazilAlagoas, BrazilAmapa
 )
 
 
@@ -46,6 +46,17 @@ class BrazilAlagoasTest(BrazilTest):
         self.assertIn(date(2017, 6, 29), holidays)  # São Pedro
         # Emancipação política de Alagoas
         self.assertIn(date(2017, 9, 16), holidays)
+        self.assertIn(date(2017, 11, 20), holidays)  # Consciência Negra
+
+
+class BrazilAmapaTest(BrazilTest):
+    cal_class = BrazilAmapa
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 3, 19), holidays)  # Dia de São José
+        self.assertIn(date(2017, 7, 25), holidays)  # São Tiago
+        self.assertIn(date(2017, 10, 5), holidays)  # Criação do estado
         self.assertIn(date(2017, 11, 20), holidays)  # Consciência Negra
 
 

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -6,7 +6,7 @@ from datetime import date
 from workalendar.tests import GenericCalendarTest
 from workalendar.america import (
     Brazil, BrazilSaoPauloState, BrazilSaoPauloCity,
-    BrazilAcre
+    BrazilAcre, BrazilAlagoas
 )
 
 
@@ -35,6 +35,18 @@ class BrazilAcreTest(BrazilTest):
         self.assertIn(date(2017, 9, 5), holidays)  # Dia da Amazônia
         # Assinatura do Tratado de Petrópolis
         self.assertIn(date(2017, 11, 17), holidays)
+
+
+class BrazilAlagoasTest(BrazilTest):
+    cal_class = BrazilAlagoas
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 6, 24), holidays)  # São João
+        self.assertIn(date(2017, 6, 29), holidays)  # São Pedro
+        # Emancipação política de Alagoas
+        self.assertIn(date(2017, 9, 16), holidays)
+        self.assertIn(date(2017, 11, 20), holidays)  # Consciência Negra
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -8,7 +8,7 @@ from workalendar.america import (
     Brazil, BrazilSaoPauloState, BrazilSaoPauloCity,
     BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas, BrazilBahia,
     BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto, BrazilGoias,
-    BrazilMaranhao,
+    BrazilMaranhao, BrazilMatoGrosso,
 )
 
 
@@ -125,6 +125,14 @@ class BrazilMaranhaoTest(BrazilTest):
         self.assertIn(date(2017, 7, 28), holidays)
         # Dia de Nossa Senhora da Conceição
         self.assertIn(date(2017, 12, 8), holidays)
+
+
+class BrazilMatoGrossoTest(BrazilTest):
+    cal_class = BrazilMatoGrosso
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 11, 29), holidays)  # Consciência Negra
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -7,6 +7,7 @@ from workalendar.tests import GenericCalendarTest
 from workalendar.america import (
     Brazil, BrazilSaoPauloState, BrazilSaoPauloCity,
     BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas, BrazilBahia,
+    BrazilCeara,
 )
 
 
@@ -78,6 +79,15 @@ class BrazilBahiaTest(BrazilTest):
     def test_year_2017(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 7, 2), holidays)  # Independência da Bahia
+
+
+class BrazilCearaTest(BrazilTest):
+    cal_class = BrazilCeara
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 3, 19), holidays)  # São José
+        self.assertIn(date(2017, 3, 23), holidays)  # Data Manga do Ceará
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -11,7 +11,7 @@ from workalendar.america import (
     BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul, BrazilPara,
     BrazilParaiba, BrazilPernambuco, BrazilPiaui, BrazilRioDeJaneiro,
     BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul, BrazilRondonia,
-    BrazilRoraima,
+    BrazilRoraima, BrazilSantaCatarina,
 )
 
 
@@ -229,6 +229,15 @@ class BrazilRoraimaTest(BrazilTest):
     def test_year_2017(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 10, 5), holidays)  # Criação de Roraima
+
+
+class BrazilSantaCatarinaTest(BrazilTest):
+    cal_class = BrazilSantaCatarina
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        # Criação da capitania, separando-se de SP
+        self.assertIn(date(2017, 8, 11), holidays)
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -9,7 +9,7 @@ from workalendar.america import (
     BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas, BrazilBahia,
     BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto, BrazilGoias,
     BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul, BrazilPara,
-    BrazilParaiba, BrazilPernambuco, BrazilPiaui,
+    BrazilParaiba, BrazilPernambuco, BrazilPiaui, BrazilRioDeJaneiro,
 )
 
 
@@ -177,6 +177,21 @@ class BrazilPiauiTest(BrazilTest):
         # Dia da Batalha do Jenipapo
         self.assertIn(date(2017, 3, 13), holidays)
         self.assertIn(date(2017, 10, 19), holidays)  # Dia do Piauí
+
+
+class BrazilRioDeJaneiroTest(BrazilTest):
+    cal_class = BrazilRioDeJaneiro
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 2, 28), holidays)  # Carnaval
+        self.assertIn(date(2017, 4, 23), holidays)  # Dia de São Jorge
+        self.assertIn(date(2017, 10, 16), holidays)  # Dia do Comércio
+        # Dia do Funcionário Público
+        self.assertIn(date(2017, 10, 28), holidays)
+        self.assertIn(date(2017, 11, 20), holidays)  # Dia da Consciência Negra
+        # Dia de Nossa Senhora da Conceição
+        self.assertIn(date(2017, 12, 8), holidays)
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -8,7 +8,7 @@ from workalendar.america import (
     Brazil, BrazilSaoPauloState, BrazilSaoPauloCity,
     BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas, BrazilBahia,
     BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto, BrazilGoias,
-    BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul,
+    BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul, BrazilPara
 )
 
 
@@ -141,6 +141,15 @@ class BrazilMatoGrossoDoSulTest(BrazilTest):
     def test_year_2017(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 10, 11), holidays)  # Criação do estado
+
+
+class BrazilParaTest(BrazilTest):
+    cal_class = BrazilPara
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        # Adesão do Grão-Pará á independência do Brasil
+        self.assertIn(date(2017, 8, 15), holidays)
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -9,7 +9,7 @@ from workalendar.america import (
     BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas, BrazilBahia,
     BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto, BrazilGoias,
     BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul, BrazilPara,
-    BrazilParaiba,
+    BrazilParaiba, BrazilPernambuco,
 )
 
 
@@ -159,6 +159,14 @@ class BrazilParaibaTest(BrazilTest):
     def test_year_2017(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 8, 5), holidays)  # Fundação do Estado
+
+
+class BrazilPernambucoTest(BrazilTest):
+    cal_class = BrazilPernambuco
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 6, 24), holidays)  # São João
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -7,7 +7,7 @@ from workalendar.tests import GenericCalendarTest
 from workalendar.america import (
     Brazil, BrazilSaoPauloState, BrazilSaoPauloCity,
     BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas, BrazilBahia,
-    BrazilCeara,
+    BrazilCeara, BrazilDistritoFederal,
 )
 
 
@@ -88,6 +88,15 @@ class BrazilCearaTest(BrazilTest):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 3, 19), holidays)  # São José
         self.assertIn(date(2017, 3, 23), holidays)  # Data Manga do Ceará
+
+
+class BrazilDistritoFederalTest(BrazilTest):
+    cal_class = BrazilDistritoFederal
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 4, 21), holidays)  # Fundação de Brasília
+        self.assertIn(date(2017, 11, 30), holidays)  # Dia do Evangélico
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -62,7 +62,13 @@ class BrazilAmapaTest(BrazilTest):
 
     def test_year_2017(self):
         holidays = self.cal.holidays_set(2017)
-        self.assertIn(date(2017, 3, 19), holidays)  # Dia de São José
+        # Dia de São José
+        sao_jose = date(2017, 3, 19)
+        self.assertIn(sao_jose, holidays)
+        # Check its label
+        self.assertEqual(
+            self.cal.get_holiday_label(sao_jose), "Dia de São José")
+
         self.assertIn(date(2017, 7, 25), holidays)  # São Tiago
         self.assertIn(date(2017, 10, 5), holidays)  # Criação do estado
         self.assertIn(date(2017, 11, 20), holidays)  # Consciência Negra
@@ -194,7 +200,15 @@ class BrazilRioDeJaneiroTest(BrazilTest):
         self.assertIn(date(2017, 10, 16), holidays)  # Dia do Comércio
         # Dia do Funcionário Público
         self.assertIn(date(2017, 10, 28), holidays)
-        self.assertIn(date(2017, 11, 20), holidays)  # Dia da Consciência Negra
+        # Dia da Consciência Negra
+        consciencia_negra = date(2017, 11, 20)
+        self.assertIn(consciencia_negra, holidays)
+        # check its label
+        self.assertEqual(
+            self.cal.get_holiday_label(consciencia_negra),
+            "Dia da Consciência Negra",
+        )
+
         # Dia de Nossa Senhora da Conceição
         self.assertIn(date(2017, 12, 8), holidays)
 
@@ -204,7 +218,13 @@ class BrazilRioGrandeDoNorteTest(BrazilTest):
 
     def test_year_2017(self):
         holidays = self.cal.holidays_set(2017)
-        self.assertIn(date(2017, 6, 29), holidays)  # Dua de São Pedro
+        # Dua de São Pedro
+        sao_pedro = date(2017, 6, 29)
+        self.assertIn(sao_pedro, holidays)
+        # Check the label
+        self.assertEqual(
+            self.cal.get_holiday_label(sao_pedro), "Dua de São Pedro"
+        )
         # Mártires de Cunhaú e Uruaçuu
         self.assertIn(date(2017, 10, 3), holidays)
 
@@ -260,7 +280,14 @@ class SaoPauloCityTest(SaoPauloStateTest):
         # Aniversário da Cidade de São Paulo
         self.assertIn(date(2013, 1, 25), holidays)
         self.assertIn(date(2013, 2, 12), holidays)  # Carnaval
-        self.assertIn(date(2013, 11, 20), holidays)  # Dia da Consciência Negra
+        # Dia da Consciência Negra
+        consciencia_negra = date(2013, 11, 20)
+        self.assertIn(consciencia_negra, holidays)
+        # check its label
+        self.assertEqual(
+            self.cal.get_holiday_label(consciencia_negra),
+            "Dia da Consciência Negra",
+        )
         self.assertIn(date(2013, 3, 31), holidays)  # Páscoa
         self.assertIn(date(2013, 5, 30), holidays)  # Corpus Christi
 
@@ -334,7 +361,13 @@ class BrazilCariacicaCityTest(BrazilTest):
         # Fixed days
         self.assertIn(date(2017, 4, 13), holidays)  # Nossa Senhora da Penha
         # São João Batista / Aniversãrio de Cariacica
-        self.assertIn(date(2017, 6, 24), holidays)
+        sao_joao = date(2017, 6, 24)
+        self.assertIn(sao_joao, holidays)
+        # Check São João label
+        self.assertEqual(
+            self.cal.get_holiday_label(sao_joao),
+            "São João Batista / Aniversãrio de Cariacica"
+        )
 
         # Variable days: Corpus Christie
         corpus_christie = date(2017, 6, 15)

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -10,6 +10,7 @@ from workalendar.america import (
     BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto, BrazilGoias,
     BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul, BrazilPara,
     BrazilParaiba, BrazilPernambuco, BrazilPiaui, BrazilRioDeJaneiro,
+    BrazilRioGrandeDoNorte,
 )
 
 
@@ -192,6 +193,16 @@ class BrazilRioDeJaneiroTest(BrazilTest):
         self.assertIn(date(2017, 11, 20), holidays)  # Dia da Consciência Negra
         # Dia de Nossa Senhora da Conceição
         self.assertIn(date(2017, 12, 8), holidays)
+
+
+class BrazilRioGrandeDoNorteTest(BrazilTest):
+    cal_class = BrazilRioGrandeDoNorte
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 6, 29), holidays)  # Dua de São Pedro
+        # Mártires de Cunhaú e Uruaçuu
+        self.assertIn(date(2017, 10, 3), holidays)
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -8,7 +8,8 @@ from workalendar.america import (
     Brazil, BrazilSaoPauloState, BrazilSaoPauloCity,
     BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas, BrazilBahia,
     BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto, BrazilGoias,
-    BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul, BrazilPara
+    BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul, BrazilPara,
+    BrazilParaiba,
 )
 
 
@@ -150,6 +151,14 @@ class BrazilParaTest(BrazilTest):
         holidays = self.cal.holidays_set(2017)
         # Adesão do Grão-Pará á independência do Brasil
         self.assertIn(date(2017, 8, 15), holidays)
+
+
+class BrazilParaibaTest(BrazilTest):
+    cal_class = BrazilParaiba
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 8, 5), holidays)  # Fundação do Estado
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -10,7 +10,7 @@ from workalendar.america import (
     BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto, BrazilGoias,
     BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul, BrazilPara,
     BrazilParaiba, BrazilPernambuco, BrazilPiaui, BrazilRioDeJaneiro,
-    BrazilRioGrandeDoNorte,
+    BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul,
 )
 
 
@@ -203,6 +203,14 @@ class BrazilRioGrandeDoNorteTest(BrazilTest):
         self.assertIn(date(2017, 6, 29), holidays)  # Dua de São Pedro
         # Mártires de Cunhaú e Uruaçuu
         self.assertIn(date(2017, 10, 3), holidays)
+
+
+class BrazilRioGrandeDoSulTest(BrazilTest):
+    cal_class = BrazilRioGrandeDoSul
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 9, 20), holidays)  # Revolução Farroupilha
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -14,7 +14,7 @@ from workalendar.america import (
     BrazilRoraima, BrazilSantaCatarina, BrazilSergipe, BrazilTocantins,
     # Cities
     BrazilSaoPauloCity, BrazilVitoriaCity, BrazilVilaVelhaCity,
-    BrazilCariacicaCity, BrazilGuarapariCity,
+    BrazilCariacicaCity, BrazilGuarapariCity, BrazilSerraCity,
 )
 
 
@@ -359,3 +359,36 @@ class BrazilGuarapariCityTest(BrazilTest):
         self.assertIn(date(2017, 9, 19), holidays),  # Emancipação de Guarapari
         self.assertIn(date(2017, 11, 29), holidays),  # Consciência Negra
         self.assertIn(date(2017, 12, 8), holidays),  # Nossa Senhora Conceição
+
+
+class BrazilSerraCityTest(BrazilTest):
+    cal_class = BrazilSerraCity
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        # Fixed days
+        self.assertIn(date(2017, 6, 29), holidays)  # São Pedro
+        self.assertIn(date(2017, 12, 8), holidays)  # Nossa Senhora Conceição
+        self.assertIn(date(2017, 12, 26), holidays)  # Dia do Serrano
+
+        # Variable days: Carnaval (Monday & Tuesday)
+        self.assertIn(date(2017, 2, 27), holidays)  # Monday
+        self.assertIn(date(2017, 2, 28), holidays)  # Tuesday
+
+        # Variable days: Ash Wednesday (Quarta-feira de cinzas)
+        ash_wednesday = date(2017, 3, 1)
+        self.assertIn(ash_wednesday, holidays)
+        # Test label
+        self.assertEqual(
+            self.cal.get_holiday_label(ash_wednesday),
+            "Quarta-feira de cinzas",
+        )
+
+        # Variable days: Good Friday (Paixão de Cristo)
+        good_friday = date(2017, 4, 14)
+        self.assertIn(good_friday, holidays)
+        # Test label
+        self.assertEqual(
+            self.cal.get_holiday_label(good_friday),
+            "Paixão do Cristo",
+        )

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -11,7 +11,7 @@ from workalendar.america import (
     BrazilMaranhao, BrazilMatoGrosso, BrazilMatoGrossoDoSul, BrazilPara,
     BrazilParaiba, BrazilPernambuco, BrazilPiaui, BrazilRioDeJaneiro,
     BrazilRioGrandeDoNorte, BrazilRioGrandeDoSul, BrazilRondonia,
-    BrazilRoraima, BrazilSantaCatarina, BrazilSergipe,
+    BrazilRoraima, BrazilSantaCatarina, BrazilSergipe, BrazilTocantins,
 )
 
 
@@ -270,3 +270,14 @@ class BrazilSergipeTest(BrazilTest):
         holidays = self.cal.holidays_set(2017)
         # Autonomia política de Sergipe
         self.assertIn(date(2017, 7, 8), holidays)
+
+
+class BrazilTocantinsTest(BrazilTest):
+    cal_class = BrazilTocantins
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 1, 1), holidays)  # Instalação de Tocantins
+        # Nossa Senhora da Natividade
+        self.assertIn(date(2017, 9, 8), holidays)
+        self.assertIn(date(2017, 10, 5), holidays)  # Criação de Tocantins

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -260,9 +260,17 @@ class SaoPauloCityTest(SaoPauloStateTest):
         self.assertIn(date(2013, 1, 25), holidays)
         self.assertIn(date(2013, 2, 12), holidays)  # Carnaval
         self.assertIn(date(2013, 11, 20), holidays)  # Dia da Consciência Negra
-        self.assertIn(date(2013, 3, 29), holidays)  # Sexta-feira da Paixão
         self.assertIn(date(2013, 3, 31), holidays)  # Páscoa
         self.assertIn(date(2013, 5, 30), holidays)  # Corpus Christi
+
+        # Variable day: Good Friday
+        good_friday = date(2013, 3, 29)
+        self.assertIn(good_friday, holidays)  # Sexta-feira da Paixão
+        # Label test
+        self.assertEqual(
+            self.cal.get_holiday_label(good_friday),
+            "Sexta-feira da Paixão",
+        )
 
 
 class BrazilSergipeTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -7,7 +7,7 @@ from workalendar.tests import GenericCalendarTest
 from workalendar.america import (
     Brazil, BrazilSaoPauloState, BrazilSaoPauloCity,
     BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas, BrazilBahia,
-    BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto,
+    BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto, BrazilGoias,
 )
 
 
@@ -101,6 +101,14 @@ class BrazilDistritoFederalTest(BrazilTest):
 
 class BrazilEspiritoSantoTest(BrazilTest):
     cal_class = BrazilEspiritoSanto
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 10, 28), holidays)  # Dia do Servidor Público
+
+
+class BrazilGoiasTest(BrazilTest):
+    cal_class = BrazilGoias
 
     def test_year_2017(self):
         holidays = self.cal.holidays_set(2017)

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -7,7 +7,7 @@ from workalendar.tests import GenericCalendarTest
 from workalendar.america import (
     Brazil, BrazilSaoPauloState, BrazilSaoPauloCity,
     BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas, BrazilBahia,
-    BrazilCeara, BrazilDistritoFederal,
+    BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto,
 )
 
 
@@ -97,6 +97,14 @@ class BrazilDistritoFederalTest(BrazilTest):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 4, 21), holidays)  # Fundação de Brasília
         self.assertIn(date(2017, 11, 30), holidays)  # Dia do Evangélico
+
+
+class BrazilEspiritoSantoTest(BrazilTest):
+    cal_class = BrazilEspiritoSanto
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 10, 28), holidays)  # Dia do Servidor Público
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -6,7 +6,7 @@ from datetime import date
 from workalendar.tests import GenericCalendarTest
 from workalendar.america import (
     Brazil, BrazilSaoPauloState, BrazilSaoPauloCity,
-    BrazilAcre, BrazilAlagoas, BrazilAmapa
+    BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas
 )
 
 
@@ -58,6 +58,18 @@ class BrazilAmapaTest(BrazilTest):
         self.assertIn(date(2017, 7, 25), holidays)  # São Tiago
         self.assertIn(date(2017, 10, 5), holidays)  # Criação do estado
         self.assertIn(date(2017, 11, 20), holidays)  # Consciência Negra
+
+
+class BrazilAmazonasTest(BrazilTest):
+    cal_class = BrazilAmazonas
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        # Elevação do Amazonas á categoria de província
+        self.assertIn(date(2017, 9, 5), holidays)
+        self.assertIn(date(2017, 11, 20), holidays)  # Consciência Negra
+        # Dia de Nossa Senhora da Conceição
+        self.assertIn(date(2017, 12, 8), holidays)
 
 
 class SaoPauloStateTest(BrazilTest):

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -14,7 +14,7 @@ from workalendar.america import (
     BrazilRoraima, BrazilSantaCatarina, BrazilSergipe, BrazilTocantins,
     # Cities
     BrazilSaoPauloCity, BrazilVitoriaCity, BrazilVilaVelhaCity,
-    BrazilCariacicaCity,
+    BrazilCariacicaCity, BrazilGuarapariCity,
 )
 
 
@@ -348,3 +348,14 @@ class BrazilCariacicaCityTest(BrazilTest):
             self.cal.get_holiday_label(good_friday),
             "Paixão do Cristo",
         )
+
+
+class BrazilGuarapariCityTest(BrazilTest):
+    cal_class = BrazilGuarapariCity
+
+    def test_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 6, 29), holidays),  # São Pedro
+        self.assertIn(date(2017, 9, 19), holidays),  # Emancipação de Guarapari
+        self.assertIn(date(2017, 11, 29), holidays),  # Consciência Negra
+        self.assertIn(date(2017, 12, 8), holidays),  # Nossa Senhora Conceição


### PR DESCRIPTION
- [x] Acre (AC)
- [x] Alagoas (AL)
- [x] Amapá (AP)
- [x] Amazonas (AM)
- [x] Bahia (BA)
- [x] Ceará (CE)
- [x] Distrito Federal (DF)
- [x] Espírito Santo State (ES)
- [x] Goiás (GO)
- [x] Maranhão (MA)
- [x] Mato Grosso (MT)
- [x] Mato Grosso do Sul (MS)
- [x] Pará (PA)
- [x] Paraíba (PB)
- [x] Pernambuco (PE)
- [x] Piauí (PI)
- [x] Rio de Janeiro (RJ)
- [x] Rio Grande do Norte (RN)
- [x] Rio Grande do Sul (RS)
- [x] Rondônia (RO)
- [x] Roraima (RR)
- [x] Santa Catarina (SC)
- [x] São Paulo (SP)
- [x] Sergipe (SE)
- [x] Tocantins (TO)
- [x] City of Vitória / ES
- [x] City of Vila Velha / ES
- [x] ~~City of Viana / ES~~ skipped, we don't have enough information to include it
- [x] City of Cariacica / ES
- [x] City of Guarapari / ES
- [x] City of Serra / ES
- [x] Figure out holidays that are duplicate and try to introduce them as class variable flags (e.g.: "São Pedro", "São João"...)
- [x] rewrite Changelog to mention the **BIG** list of added calendars.