### PR TITLE
Added Good Friday in the list of Hungarian holidays, as of the year 2017

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ master (unreleased)
 
 - Added Singapore calendar, initiated by @nedlowe (#194 + #195).
 - Added Malaysia, by @gregyhj (#201).
+- Added Good Friday in the list of Hungarian holidays, as of the year 2017 (#203), thx to @mariusz-korzekwa for the bug report.
 
 1.2.0 (2017-05-30)
 ------------------

--- a/workalendar/europe/hungary.py
+++ b/workalendar/europe/hungary.py
@@ -20,3 +20,9 @@ class Hungary(WesternCalendar, ChristianMixin):
         (8, 20, "St Stephen's Day"),
         (10, 23, "National Day"),
     )
+
+    def get_variable_days(self, year):
+        days = super(Hungary, self).get_variable_days(year)
+        if year >= 2017:
+            days.append((self.get_good_friday(year), self.good_friday_label))
+        return days

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -380,6 +380,17 @@ class HungaryTest(GenericCalendarTest):
         self.assertIn(date(2013, 12, 25), holidays)  # XMas
         self.assertIn(date(2013, 12, 26), holidays)  # Second day of XMas
 
+    def test_year_good_friday(self):
+        # Since the year 2017, Good Friday is a non-working day un Hungary
+        # Refs #203
+        holidays = self.cal.holidays_set(2016)
+        good_friday_2016 = date(2016, 3, 25)
+        self.assertNotIn(good_friday_2016, holidays)
+        # 2017
+        holidays = self.cal.holidays_set(2017)
+        good_friday_2017 = date(2017, 4, 14)
+        self.assertIn(good_friday_2017, holidays)
+
 
 class MaltaTest(GenericCalendarTest):
     """Rollover rules changed in 2005"""


### PR DESCRIPTION
refs #203

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.
