### PR TITLE
Assigned a minimal setuptools version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ master (unreleased)
 - Added Singapore calendar, initiated by @nedlowe (#194 + #195).
 - Added Malaysia, by @gregyhj (#201).
 - Added Good Friday in the list of Hungarian holidays, as of the year 2017 (#203), thx to @mariusz-korzekwa for the bug report.
+- Assigned a minimal setuptools version, to avoid naughty ``DistributionNotFound`` exceptions with obsolete versions (#74).
 
 1.2.0 (2017-05-30)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ REQUIREMENTS = [
     'lunardate',
     'pytz',
     'pyCalverter',
+    'setuptools==0.6c11',
 ]
 version = '1.3.0.dev0'
 __VERSION__ = version

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIREMENTS = [
     'lunardate',
     'pytz',
     'pyCalverter',
-    'setuptools==0.6c11',
+    'setuptools==1.0',
 ]
 version = '1.3.0.dev0'
 __VERSION__ = version

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIREMENTS = [
     'lunardate',
     'pytz',
     'pyCalverter',
-    'setuptools==1.0',
+    'setuptools>=1.0',
 ]
 version = '1.3.0.dev0'
 __VERSION__ = version


### PR DESCRIPTION
refs #74

Assigned a minimal setuptools version, to avoid naughty ``DistributionNotFound`` exceptions with obsolete versions.

I've been as permissive as possible, starting with a several-year-old minimum, that will guarantee that it should not disturb the requirement computation. If the user other requirements require a more recent version, they won't be locked out.