### PR TITLE
De-duplicated XMas day, which was configured twice

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ master (unreleased)
 - Added Malaysia, by @gregyhj (#201).
 - Added Good Friday in the list of Hungarian holidays, as of the year 2017 (#203), thx to @mariusz-korzekwa for the bug report.
 - Assigned a minimal setuptools version, to avoid naughty ``DistributionNotFound`` exceptions with obsolete versions (#74).
+- Fixed a bug in Slovakia calendar, de-duplicated Christmas Day, that appeared twice (#205).
 
 1.2.0 (2017-05-30)
 ------------------

--- a/workalendar/europe/slovakia.py
+++ b/workalendar/europe/slovakia.py
@@ -7,6 +7,10 @@ class Slovakia(WesternCalendar, ChristianMixin):
     include_epiphany = True
     include_easter_monday = True
     include_good_friday = True
+    include_all_saints = True
+    include_christmas_eve = True
+    include_boxing_day = True
+    boxing_day_label = "St. Stephen's Day (The Second Christmas Day)"
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (1, 1, "Day of the Establishment of the Slovak Republic"),
@@ -16,9 +20,5 @@ class Slovakia(WesternCalendar, ChristianMixin):
         (8, 29, "Slovak National Uprising anniversary"),
         (9, 1, "Day of the Constitution of the Slovak Republic"),
         (9, 15, "Day of Blessed Virgin Mary, patron saint of Slovakia"),
-        (11, 1, "All Saints’ Day"),
         (11, 17, "Struggle for Freedom and Democracy Day"),
-        (12, 24, "Christmas Eve"),
-        (12, 25, "Christmas Day"),
-        (12, 26, "St. Stephen's Day (The Second Christmas Day)"),
     )

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -1,5 +1,7 @@
 # coding=utf-8
 from datetime import date
+from collections import Counter
+
 from workalendar.tests import GenericCalendarTest
 from workalendar.europe import Austria
 from workalendar.europe import Bulgaria
@@ -193,6 +195,19 @@ class SlovakiaTest(GenericCalendarTest):
         self.assertIn(date(2013, 12, 24), holidays)
         self.assertIn(date(2013, 12, 25), holidays)
         self.assertIn(date(2013, 12, 26), holidays)
+
+    def test_removed_duplicate(self):
+        holidays = self.cal.holidays(2017)
+        counter = Counter(day for day, label in holidays)
+        # Only one "all saints"
+        self.assertEqual(counter[date(2017, 11, 1)], 1)
+        # Only one "XMas eve"
+        self.assertEqual(counter[date(2017, 12, 24)], 1)
+        # De-duplicate, XMas day was configured twice.
+        # Refs #205.
+        self.assertEqual(counter[date(2017, 12, 25)], 1)
+        # Only one St Stephen
+        self.assertEqual(counter[date(2017, 12, 25)], 1)
 
 
 class SwedenTest(GenericCalendarTest):


### PR DESCRIPTION
closes #205

While I was at it, I've reconfigured some variable christian days that were included in the `ChristianMixin`, but were configured as "fixed days".

* All saints day
* Christmas eve
* St Stephen's day

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.
