### PR TITLE
Fix city holidays in Brazil calendars

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ master (unreleased)
 - Added Good Friday in the list of Hungarian holidays, as of the year 2017 (#203), thx to @mariusz-korzekwa for the bug report.
 - Assigned a minimal setuptools version, to avoid naughty ``DistributionNotFound`` exceptions with obsolete versions (#74).
 - Fixed a bug in Slovakia calendar, de-duplicated Christmas Day, that appeared twice (#205).
+- Fixed important bugs in the calendars of the following Brazilian cities: Vitória, Vila Velha, Cariacica, Guarapari and Serra - thx to Fernanda Gonçalves Rodrigues, who confirmed this issue raised by @Skippern (#199).
 
 1.2.0 (2017-05-30)
 ------------------

--- a/workalendar/america/brazil.py
+++ b/workalendar/america/brazil.py
@@ -290,9 +290,9 @@ class BrazilTocantins(Brazil):
     )
 
 
-class BrazilVitoriaCity(Brazil):
+class BrazilVitoriaCity(BrazilEspiritoSanto):
     "Brazil Vitória City"
-    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+    FIXED_HOLIDAYS = BrazilEspiritoSanto.FIXED_HOLIDAYS + (
         (4, 24, "Nossa Senhora da Penha"),  # Our Lady of Pain?
         (9, 8, "Nossa Senhora da Vitória"),  # Our Lady of Vitória
     )
@@ -301,16 +301,16 @@ class BrazilVitoriaCity(Brazil):
     good_friday_label = "Paixão do Cristo"
 
 
-class BrazilVilaVelhaCity(Brazil):
+class BrazilVilaVelhaCity(BrazilEspiritoSanto):
     "Brazil Vila Velha City"
-    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+    FIXED_HOLIDAYS = BrazilEspiritoSanto.FIXED_HOLIDAYS + (
         (5, 23, "Colonização do Solo Espírito-santense"),
     )
 
 
-class BrazilCariacicaCity(Brazil):
+class BrazilCariacicaCity(BrazilEspiritoSanto):
     "Brazil Cariacica City"
-    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+    FIXED_HOLIDAYS = BrazilEspiritoSanto.FIXED_HOLIDAYS + (
         (4, 13, "Nossa Senhora da Penha"),
     )
     include_corpus_christi = True
@@ -320,9 +320,9 @@ class BrazilCariacicaCity(Brazil):
     sao_joao_label = "São João Batista / Aniversãrio de Cariacica"
 
 
-class BrazilGuarapariCity(Brazil):
+class BrazilGuarapariCity(BrazilEspiritoSanto):
     "Brazil Guarapari City"
-    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+    FIXED_HOLIDAYS = BrazilEspiritoSanto.FIXED_HOLIDAYS + (
         (9, 19, "Emancipação de Guarapari"),
     )
     include_sao_pedro = True
@@ -331,9 +331,9 @@ class BrazilGuarapariCity(Brazil):
     include_nossa_senhora_conceicao = True
 
 
-class BrazilSerraCity(Brazil):
+class BrazilSerraCity(BrazilEspiritoSanto):
     "Brazil Serra City"
-    FIXED_HOLIDAYS = Brazil.FIXED_HOLIDAYS + (
+    FIXED_HOLIDAYS = BrazilEspiritoSanto.FIXED_HOLIDAYS + (
         (12, 26, "Dia do Serrano"),
     )
     include_ash_wednesday = True

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -21,7 +21,7 @@ from workalendar.america import (
 class BrazilTest(GenericCalendarTest):
     cal_class = Brazil
 
-    def test_year_2013(self):
+    def test_year_2013_federal(self):
         holidays = self.cal.holidays_set(2013)
         self.assertIn(date(2013, 1, 1), holidays)  # new year
         self.assertIn(date(2013, 4, 21), holidays)  # Tiradentes
@@ -36,7 +36,7 @@ class BrazilTest(GenericCalendarTest):
 class BrazilAcreTest(BrazilTest):
     cal_class = BrazilAcre
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 1, 23), holidays)  # Dia do evangélico
         self.assertIn(date(2017, 6, 15), holidays)  # niversário do Acre
@@ -48,7 +48,7 @@ class BrazilAcreTest(BrazilTest):
 class BrazilAlagoasTest(BrazilTest):
     cal_class = BrazilAlagoas
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 6, 24), holidays)  # São João
         self.assertIn(date(2017, 6, 29), holidays)  # São Pedro
@@ -60,7 +60,7 @@ class BrazilAlagoasTest(BrazilTest):
 class BrazilAmapaTest(BrazilTest):
     cal_class = BrazilAmapa
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         # Dia de São José
         sao_jose = date(2017, 3, 19)
@@ -77,7 +77,7 @@ class BrazilAmapaTest(BrazilTest):
 class BrazilAmazonasTest(BrazilTest):
     cal_class = BrazilAmazonas
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         # Elevação do Amazonas á categoria de província
         self.assertIn(date(2017, 9, 5), holidays)
@@ -89,7 +89,7 @@ class BrazilAmazonasTest(BrazilTest):
 class BrazilBahiaTest(BrazilTest):
     cal_class = BrazilBahia
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 7, 2), holidays)  # Independência da Bahia
 
@@ -97,7 +97,7 @@ class BrazilBahiaTest(BrazilTest):
 class BrazilCearaTest(BrazilTest):
     cal_class = BrazilCeara
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 3, 19), holidays)  # São José
         self.assertIn(date(2017, 3, 23), holidays)  # Data Manga do Ceará
@@ -106,7 +106,7 @@ class BrazilCearaTest(BrazilTest):
 class BrazilDistritoFederalTest(BrazilTest):
     cal_class = BrazilDistritoFederal
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 4, 21), holidays)  # Fundação de Brasília
         self.assertIn(date(2017, 11, 30), holidays)  # Dia do Evangélico
@@ -115,7 +115,7 @@ class BrazilDistritoFederalTest(BrazilTest):
 class BrazilEspiritoSantoTest(BrazilTest):
     cal_class = BrazilEspiritoSanto
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 10, 28), holidays)  # Dia do Servidor Público
 
@@ -123,7 +123,7 @@ class BrazilEspiritoSantoTest(BrazilTest):
 class BrazilGoiasTest(BrazilTest):
     cal_class = BrazilGoias
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 10, 28), holidays)  # Dia do Servidor Público
 
@@ -131,7 +131,7 @@ class BrazilGoiasTest(BrazilTest):
 class BrazilMaranhaoTest(BrazilTest):
     cal_class = BrazilMaranhao
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         # Adesão do Maranhão á independência do Brasil
         self.assertIn(date(2017, 7, 28), holidays)
@@ -142,7 +142,7 @@ class BrazilMaranhaoTest(BrazilTest):
 class BrazilMatoGrossoTest(BrazilTest):
     cal_class = BrazilMatoGrosso
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 11, 29), holidays)  # Consciência Negra
 
@@ -150,7 +150,7 @@ class BrazilMatoGrossoTest(BrazilTest):
 class BrazilMatoGrossoDoSulTest(BrazilTest):
     cal_class = BrazilMatoGrossoDoSul
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 10, 11), holidays)  # Criação do estado
 
@@ -158,7 +158,7 @@ class BrazilMatoGrossoDoSulTest(BrazilTest):
 class BrazilParaTest(BrazilTest):
     cal_class = BrazilPara
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         # Adesão do Grão-Pará á independência do Brasil
         self.assertIn(date(2017, 8, 15), holidays)
@@ -167,7 +167,7 @@ class BrazilParaTest(BrazilTest):
 class BrazilParaibaTest(BrazilTest):
     cal_class = BrazilParaiba
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 8, 5), holidays)  # Fundação do Estado
 
@@ -175,7 +175,7 @@ class BrazilParaibaTest(BrazilTest):
 class BrazilPernambucoTest(BrazilTest):
     cal_class = BrazilPernambuco
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 6, 24), holidays)  # São João
 
@@ -183,7 +183,7 @@ class BrazilPernambucoTest(BrazilTest):
 class BrazilPiauiTest(BrazilTest):
     cal_class = BrazilPiaui
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         # Dia da Batalha do Jenipapo
         self.assertIn(date(2017, 3, 13), holidays)
@@ -193,7 +193,7 @@ class BrazilPiauiTest(BrazilTest):
 class BrazilRioDeJaneiroTest(BrazilTest):
     cal_class = BrazilRioDeJaneiro
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 2, 28), holidays)  # Carnaval
         self.assertIn(date(2017, 4, 23), holidays)  # Dia de São Jorge
@@ -216,7 +216,7 @@ class BrazilRioDeJaneiroTest(BrazilTest):
 class BrazilRioGrandeDoNorteTest(BrazilTest):
     cal_class = BrazilRioGrandeDoNorte
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         # Dua de São Pedro
         sao_pedro = date(2017, 6, 29)
@@ -232,7 +232,7 @@ class BrazilRioGrandeDoNorteTest(BrazilTest):
 class BrazilRioGrandeDoSulTest(BrazilTest):
     cal_class = BrazilRioGrandeDoSul
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 9, 20), holidays)  # Revolução Farroupilha
 
@@ -240,7 +240,7 @@ class BrazilRioGrandeDoSulTest(BrazilTest):
 class BrazilRondoniaTest(BrazilTest):
     cal_class = BrazilRondonia
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 1, 4), holidays)  # Criação do estado
         self.assertIn(date(2017, 6, 18), holidays)  # Dia do Evangélico
@@ -249,7 +249,7 @@ class BrazilRondoniaTest(BrazilTest):
 class BrazilRoraimaTest(BrazilTest):
     cal_class = BrazilRoraima
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 10, 5), holidays)  # Criação de Roraima
 
@@ -257,7 +257,7 @@ class BrazilRoraimaTest(BrazilTest):
 class BrazilSantaCatarinaTest(BrazilTest):
     cal_class = BrazilSantaCatarina
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         # Criação da capitania, separando-se de SP
         self.assertIn(date(2017, 8, 11), holidays)
@@ -266,7 +266,7 @@ class BrazilSantaCatarinaTest(BrazilTest):
 class SaoPauloStateTest(BrazilTest):
     cal_class = BrazilSaoPauloState
 
-    def test_regional_2013(self):
+    def test_year_2013_state(self):
         holidays = self.cal.holidays_set(2013)
         # Revolução Constitucionalista de 1932
         self.assertIn(date(2013, 7, 9), holidays)
@@ -275,7 +275,7 @@ class SaoPauloStateTest(BrazilTest):
 class SaoPauloCityTest(SaoPauloStateTest):
     cal_class = BrazilSaoPauloCity
 
-    def test_city_2013(self):
+    def test_year_2013_city(self):
         holidays = self.cal.holidays_set(2013)
         # Aniversário da Cidade de São Paulo
         self.assertIn(date(2013, 1, 25), holidays)
@@ -304,7 +304,7 @@ class SaoPauloCityTest(SaoPauloStateTest):
 class BrazilSergipeTest(BrazilTest):
     cal_class = BrazilSergipe
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         # Autonomia política de Sergipe
         self.assertIn(date(2017, 7, 8), holidays)
@@ -313,7 +313,7 @@ class BrazilSergipeTest(BrazilTest):
 class BrazilTocantinsTest(BrazilTest):
     cal_class = BrazilTocantins
 
-    def test_year_2017(self):
+    def test_year_2017_state(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 1, 1), holidays)  # Instalação de Tocantins
         # Nossa Senhora da Natividade
@@ -324,7 +324,7 @@ class BrazilTocantinsTest(BrazilTest):
 class BrazilVitoriaCityTest(BrazilTest):
     cal_class = BrazilVitoriaCity
 
-    def test_year_2017(self):
+    def test_year_2017_city(self):
         holidays = self.cal.holidays_set(2017)
         # Fixed days
         self.assertIn(date(2017, 4, 24), holidays)  # Nossa Senhora da Penha
@@ -347,7 +347,7 @@ class BrazilVitoriaCityTest(BrazilTest):
 class BrazilVilaVelhaCityTest(BrazilTest):
     cal_class = BrazilVilaVelhaCity
 
-    def test_year_2017(self):
+    def test_year_2017_city(self):
         holidays = self.cal.holidays_set(2017)
         # Colonização do Solo Espírito-santense
         self.assertIn(date(2017, 5, 23), holidays)
@@ -356,7 +356,7 @@ class BrazilVilaVelhaCityTest(BrazilTest):
 class BrazilCariacicaCityTest(BrazilTest):
     cal_class = BrazilCariacicaCity
 
-    def test_year_2017(self):
+    def test_year_2017_city(self):
         holidays = self.cal.holidays_set(2017)
         # Fixed days
         self.assertIn(date(2017, 4, 13), holidays)  # Nossa Senhora da Penha
@@ -386,7 +386,7 @@ class BrazilCariacicaCityTest(BrazilTest):
 class BrazilGuarapariCityTest(BrazilTest):
     cal_class = BrazilGuarapariCity
 
-    def test_year_2017(self):
+    def test_year_2017_city(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 6, 29), holidays),  # São Pedro
         self.assertIn(date(2017, 9, 19), holidays),  # Emancipação de Guarapari
@@ -397,7 +397,7 @@ class BrazilGuarapariCityTest(BrazilTest):
 class BrazilSerraCityTest(BrazilTest):
     cal_class = BrazilSerraCity
 
-    def test_year_2017(self):
+    def test_year_2017_city(self):
         holidays = self.cal.holidays_set(2017)
         # Fixed days
         self.assertIn(date(2017, 6, 29), holidays)  # São Pedro

--- a/workalendar/tests/test_brazil.py
+++ b/workalendar/tests/test_brazil.py
@@ -321,7 +321,10 @@ class BrazilTocantinsTest(BrazilTest):
         self.assertIn(date(2017, 10, 5), holidays)  # Criação de Tocantins
 
 
-class BrazilVitoriaCityTest(BrazilTest):
+class BrazilVitoriaCityTest(BrazilEspiritoSantoTest):
+    """
+    Vitória city is in the Espírito Santo state
+    """
     cal_class = BrazilVitoriaCity
 
     def test_year_2017_city(self):
@@ -344,7 +347,10 @@ class BrazilVitoriaCityTest(BrazilTest):
         )
 
 
-class BrazilVilaVelhaCityTest(BrazilTest):
+class BrazilVilaVelhaCityTest(BrazilEspiritoSantoTest):
+    """
+    Vila Velha city is in the Espírito Santo state
+    """
     cal_class = BrazilVilaVelhaCity
 
     def test_year_2017_city(self):
@@ -353,7 +359,10 @@ class BrazilVilaVelhaCityTest(BrazilTest):
         self.assertIn(date(2017, 5, 23), holidays)
 
 
-class BrazilCariacicaCityTest(BrazilTest):
+class BrazilCariacicaCityTest(BrazilEspiritoSantoTest):
+    """
+    Cariacica city is in the Espírito Santo state
+    """
     cal_class = BrazilCariacicaCity
 
     def test_year_2017_city(self):
@@ -383,7 +392,10 @@ class BrazilCariacicaCityTest(BrazilTest):
         )
 
 
-class BrazilGuarapariCityTest(BrazilTest):
+class BrazilGuarapariCityTest(BrazilEspiritoSantoTest):
+    """
+    Guarapari city is in the Espírito Santo state
+    """
     cal_class = BrazilGuarapariCity
 
     def test_year_2017_city(self):
@@ -394,7 +406,10 @@ class BrazilGuarapariCityTest(BrazilTest):
         self.assertIn(date(2017, 12, 8), holidays),  # Nossa Senhora Conceição
 
 
-class BrazilSerraCityTest(BrazilTest):
+class BrazilSerraCityTest(BrazilEspiritoSantoTest):
+    """
+    Serra city is in the Espírito Santo state
+    """
     cal_class = BrazilSerraCity
 
     def test_year_2017_city(self):


### PR DESCRIPTION
refs #199

- [x] Tests with a significant number of years to be tested for your calendar.
- [x] Changelog amended with a mention describing your changes.
- [x] Vitória (ES)
- [x] Vila Velha (ES)
- [x] Cariacica (ES)
- [x] Guarapari (ES)
- [x] Serra (ES)
