### PR TITLE
Minor cleanups

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@ master (unreleased)
 -------------------
 
 - Run tests with Python3.6 in CI (#210)
-
+- Small refactors / cleanups in the following calendars: Hungary, Iceland, Ireland, Latvia, Netherlands, Spain, Japan, Taiwan, Australia, Canada, USA (#209).
 
 1.3.0 (2017-06-09)
 ------------------

--- a/workalendar/asia.py
+++ b/workalendar/asia.py
@@ -35,28 +35,20 @@ class Japan(WesternCalendar, EphemMixin):
 
     def get_variable_days(self, year):
         # usual variable days
-
-        equinoxes = self.calculate_equinoxes(year, 'Asia/Tokyo')
-
         days = super(Japan, self).get_variable_days(year)
-        days += [
-            (Japan.get_nth_weekday_in_month(year, 1, MON, 2),
-                'Coming of Age Day'),
-
-            (Japan.get_nth_weekday_in_month(year, 7, MON, 3),
-                "Marine Day"),
-
+        equinoxes = self.calculate_equinoxes(year, 'Asia/Tokyo')
+        coming_of_age_day = Japan.get_nth_weekday_in_month(year, 1, MON, 2)
+        marine_day = Japan.get_nth_weekday_in_month(year, 7, MON, 3)
+        respect_for_the_aged = Japan.get_nth_weekday_in_month(year, 9, MON, 3)
+        health_and_sport = Japan.get_nth_weekday_in_month(year, 10, MON, 2)
+        days.extend([
+            (coming_of_age_day, 'Coming of Age Day'),
+            (marine_day, "Marine Day"),
             (equinoxes[0], "Vernal Equinox Day"),
-
-            (Japan.get_nth_weekday_in_month(year, 9, MON, 3),
-                "Respect-for-the-Aged Day"),
-
+            (respect_for_the_aged, "Respect-for-the-Aged Day"),
             (equinoxes[1], "Autumnal Equinox Day"),
-
-            (Japan.get_nth_weekday_in_month(year, 10, MON, 2),
-                "Health and Sports Day"),
-        ]
-
+            (health_and_sport, "Health and Sports Day"),
+        ])
         return days
 
 
@@ -341,14 +333,13 @@ class Taiwan(EphemMixin, LunarCalendar, WesternCalendar):
     )
 
     def get_variable_days(self, year):
+        days = super(Taiwan, self).get_variable_days(year)
         lunar_first_day = LunarCalendar.lunar(year, 1, 1)
-
         # Qingming begins when the sun reaches the celestial
         # longitude of 15° (usually around April 4th or 5th)
         qingming = EphemMixin.solar_term(self, year, 15, 'Asia/Taipei')
 
-        days = super(Taiwan, self).get_variable_days(year)
-        days += [
+        days.extend([
             # a day before
             (lunar_first_day - timedelta(days=1), "Chinese New Year's Eve"),
             (lunar_first_day, "Chinese New Year"),
@@ -358,5 +349,5 @@ class Taiwan(EphemMixin, LunarCalendar, WesternCalendar):
             (qingming, "Qingming Festival"),
             (LunarCalendar.lunar(year, 5, 5), "Dragon Boat Festival"),
             (LunarCalendar.lunar(year, 8, 15), "Mid-Autumn Festival"),
-        ]
+        ])
         return days

--- a/workalendar/canada.py
+++ b/workalendar/canada.py
@@ -17,9 +17,10 @@ class Canada(WesternCalendar, ChristianMixin):
     def get_variable_days(self, year):
         # usual variable days
         days = super(Canada, self).get_variable_days(year)
-        days += [
+        days.append(
             (Canada.get_nth_weekday_in_month(year, 9, MON, 1), "Labor Day")
-        ]
+        )
+        # Canada day
         canadaday = date(year, 7, 1)
         if canadaday.weekday() in self.get_weekend_days():
             shift = self.find_following_working_day(canadaday)
@@ -58,16 +59,15 @@ class AugustCivicHolidayMixin(Calendar):
     "1st Monday of August; different names depending on location"
 
     def get_civic_holiday(self, year, label="Civic Holiday"):
-        return (self.get_nth_weekday_in_month(year, 8, MON),
-                label)
+        return (self.get_nth_weekday_in_month(year, 8, MON), label)
 
 
 class ThanksgivingMixin(Calendar):
     "2nd Monday of October"
 
     def get_thanksgiving(self, year):
-        return (self.get_nth_weekday_in_month(year, 10, MON, 2),
-                "Thanksgiving")
+        thanksgiving = self.get_nth_weekday_in_month(year, 10, MON, 2)
+        return (thanksgiving, "Thanksgiving")
 
 
 class BoxingDayMixin(Calendar):
@@ -120,13 +120,13 @@ class Ontario(Canada, BoxingDayMixin, ThanksgivingMixin, VictoriaDayMixin,
 
     def get_variable_days(self, year):
         days = super(Ontario, self).get_variable_days(year)
-        days += [
+        days.extend([
             (self.get_family_day(year)),
             (self.get_victoria_day(year)),
             (self.get_civic_holiday(year, "Civic Holiday (Not for all)")),
             (self.get_thanksgiving(year)),
-        ]
-        days += self.get_boxing_day(year)
+        ])
+        days.extend(self.get_boxing_day(year))
 
         return days
 
@@ -137,12 +137,11 @@ class Quebec(Canada, VictoriaDayMixin, StJeanBaptisteMixin, ThanksgivingMixin):
 
     def get_variable_days(self, year):
         days = super(Quebec, self).get_variable_days(year)
-        days += [
+        days.extend([
             (self.get_victoria_day(year)),
             (self.get_thanksgiving(year)),
-        ]
-        days += self.get_st_jean(year)
-
+        ])
+        days.extend(self.get_st_jean(year))
         return days
 
 
@@ -158,13 +157,12 @@ class BritishColumbia(Canada, VictoriaDayMixin, AugustCivicHolidayMixin,
 
     def get_variable_days(self, year):
         days = super(BritishColumbia, self).get_variable_days(year)
-        days += [
+        days.extend([
             (self.get_family_day(year)),
             (self.get_victoria_day(year)),
             (self.get_civic_holiday(year, "British Columbia Day")),
             (self.get_thanksgiving(year)),
-        ]
-
+        ])
         return days
 
 
@@ -178,12 +176,11 @@ class Alberta(Canada, LateFamilyDayMixin, VictoriaDayMixin, ThanksgivingMixin):
 
     def get_variable_days(self, year):
         days = super(Alberta, self).get_variable_days(year)
-        days += [
+        days.extend([
             (self.get_family_day(year)),
             (self.get_victoria_day(year)),
             (self.get_thanksgiving(year)),
-        ]
-
+        ])
         return days
 
 
@@ -195,14 +192,13 @@ class Saskatchewan(Canada, LateFamilyDayMixin, VictoriaDayMixin,
 
     def get_variable_days(self, year):
         days = super(Saskatchewan, self).get_variable_days(year)
-        days += [
+        days.extend([
             (self.get_family_day(year)),
             (self.get_victoria_day(year)),
             (self.get_civic_holiday(year)),
             (self.get_thanksgiving(year)),
-        ]
-        days += self.get_remembrance_day(year)
-
+        ])
+        days.extend(self.get_remembrance_day(year))
         return days
 
 
@@ -213,13 +209,12 @@ class Manitoba(Canada, LateFamilyDayMixin, VictoriaDayMixin,
 
     def get_variable_days(self, year):
         days = super(Manitoba, self).get_variable_days(year)
-        days += [
+        days.extend([
             (self.get_family_day(year, "Louis Riel Day")),
             (self.get_victoria_day(year)),
             (self.get_civic_holiday(year)),
             (self.get_thanksgiving(year)),
-        ]
-
+        ])
         return days
 
 
@@ -234,9 +229,7 @@ class NewBrunswick(Canada, AugustCivicHolidayMixin):
 
     def get_variable_days(self, year):
         days = super(NewBrunswick, self).get_variable_days(year)
-        days += [
-            (self.get_civic_holiday(year)),
-        ]
+        days.append(self.get_civic_holiday(year))
         return days
 
 
@@ -247,13 +240,9 @@ class NovaScotia(Canada, RemembranceDayShiftMixin, LateFamilyDayMixin):
 
     def get_variable_days(self, year):
         days = super(NovaScotia, self).get_variable_days(year)
-        days += (self.get_remembrance_day(year))
-
+        days.extend(self.get_remembrance_day(year))
         if year >= 2015:
-            days += [
-                (self.get_family_day(year, "Viola Desmond Day")),
-            ]
-
+            days.append(self.get_family_day(year, "Viola Desmond Day"))
         return days
 
 
@@ -264,11 +253,8 @@ class PrinceEdwardIsland(Canada, LateFamilyDayMixin, RemembranceDayShiftMixin):
 
     def get_variable_days(self, year):
         days = super(PrinceEdwardIsland, self).get_variable_days(year)
-        days += [
-            (self.get_family_day(year, "Islander Day")),
-        ]
-        days += (self.get_remembrance_day(year))
-
+        days.append((self.get_family_day(year, "Islander Day")))
+        days.extend(self.get_remembrance_day(year))
         return days
 
 
@@ -288,13 +274,11 @@ class Yukon(Canada, VictoriaDayMixin, ThanksgivingMixin):
 
     def get_variable_days(self, year):
         days = super(Yukon, self).get_variable_days(year)
-        days += [
-            (self.get_nth_weekday_in_month(year, 8, MON, 3),
-             "Discovery Day"),
+        days.extend([
+            (self.get_nth_weekday_in_month(year, 8, MON, 3), "Discovery Day"),
             (self.get_victoria_day(year)),
             (self.get_thanksgiving(year)),
-        ]
-
+        ])
         return days
 
 
@@ -310,13 +294,11 @@ class NorthwestTerritories(Canada, RemembranceDayShiftMixin, VictoriaDayMixin,
 
     def get_variable_days(self, year):
         days = super(NorthwestTerritories, self).get_variable_days(year)
-        days += [
+        days.extend([
             (self.get_victoria_day(year)),
             (self.get_thanksgiving(year)),
-        ]
-
-        days += (self.get_remembrance_day(year))
-
+        ])
+        days.extend(self.get_remembrance_day(year))
         return days
 
 
@@ -327,15 +309,15 @@ class Nunavut(Canada, VictoriaDayMixin, ThanksgivingMixin,
 
     def get_variable_days(self, year):
         days = super(Nunavut, self).get_variable_days(year)
-        days += [
+        days.extend([
             (self.get_victoria_day(year)),
             (self.get_thanksgiving(year)),
-        ]
+        ])
 
-        days += (self.get_remembrance_day(year))
+        days.extend(self.get_remembrance_day(year))
+
         nuvanutday = date(year, 7, 9)
-        days += [(nuvanutday, "Nuvanut Day")]
+        days.append((nuvanutday, "Nuvanut Day"))
         if nuvanutday.weekday() == SUN:
-            days += [(date(year, 7, 10), "Nuvanut Day (Shift)")]
-
+            days.append((date(year, 7, 10), "Nuvanut Day (Shift)"))
         return days

--- a/workalendar/europe/hungary.py
+++ b/workalendar/europe/hungary.py
@@ -22,7 +22,7 @@ class Hungary(WesternCalendar, ChristianMixin):
     )
 
     def get_variable_days(self, year):
+        # As of 2017, Good Friday became a holiday
+        self.include_good_friday = (year >= 2017)
         days = super(Hungary, self).get_variable_days(year)
-        if year >= 2017:
-            days.append((self.get_good_friday(year), self.good_friday_label))
         return days

--- a/workalendar/europe/iceland.py
+++ b/workalendar/europe/iceland.py
@@ -25,18 +25,17 @@ class Iceland(WesternCalendar, ChristianMixin):
         """It's the first thursday *after* April, 18th.
         If April the 18th is a thursday, then it jumps to the 24th.
         """
-        return WesternCalendar.get_nth_weekday_in_month(
+        return Iceland.get_nth_weekday_in_month(
             year, 4, THU,
             start=date(year, 4, 19))
 
+    def get_commerce_day(self, year):
+        return Iceland.get_nth_weekday_in_month(year, 8, MON)
+
     def get_variable_days(self, year):
         days = super(Iceland, self).get_variable_days(year)
-        days += [
-            (
-                self.get_first_day_of_summer(year),
-                "First day of summer"),
-            (
-                Iceland.get_nth_weekday_in_month(year, 8, MON),
-                "Commerce Day"),
-        ]
+        days.extend([
+            (self.get_first_day_of_summer(year), "First day of summer"),
+            (self.get_commerce_day(year), "Commerce Day"),
+        ])
         return days

--- a/workalendar/europe/ireland.py
+++ b/workalendar/europe/ireland.py
@@ -25,6 +25,7 @@ class Ireland(WesternCalendar, ChristianMixin):
         )
 
     def get_variable_days(self, year):
+        self.include_whit_monday = (year <= 1973)
         days = super(Ireland, self).get_variable_days(year)
 
         # St Patrick's day
@@ -34,13 +35,6 @@ class Ireland(WesternCalendar, ChristianMixin):
             days.append((
                 self.find_following_working_day(st_patrick),
                 "Saint Patrick substitute"))
-
-        # Whit Monday
-        if year <= 1973:
-            days.append((
-                self.get_whit_monday(year),
-                self.whit_monday_label
-            ))
 
         # May Day
         if year >= 1994:

--- a/workalendar/europe/latvia.py
+++ b/workalendar/europe/latvia.py
@@ -45,6 +45,6 @@ class Latvia(WesternCalendar, ChristianMixin):
 
     def get_variable_days(self, year):
         days = super(Latvia, self).get_variable_days(year)
-        days += self.get_independence_days(year)
-        days += self.get_republic_days(year)
+        days.extend(self.get_independence_days(year))
+        days.extend(self.get_republic_days(year))
         return days

--- a/workalendar/europe/netherlands.py
+++ b/workalendar/europe/netherlands.py
@@ -36,7 +36,5 @@ class Netherlands(WesternCalendar, ChristianMixin):
 
     def get_variable_days(self, year):
         days = super(Netherlands, self).get_variable_days(year)
-        days += [
-            self.get_king_queen_day(year)
-        ]
+        days.append(self.get_king_queen_day(year))
         return days

--- a/workalendar/europe/portugal.py
+++ b/workalendar/europe/portugal.py
@@ -23,5 +23,4 @@ class Portugal(WesternCalendar, ChristianMixin):
     def get_variable_days(self, year):
         days = super(Portugal, self).get_variable_days(year)
         days.append((self.get_variable_entrudo(year), "Entrudo"))
-
         return days

--- a/workalendar/europe/spain.py
+++ b/workalendar/europe/spain.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 from workalendar.core import WesternCalendar, ChristianMixin
 
 
@@ -11,9 +13,9 @@ class Spain(WesternCalendar, ChristianMixin):
     include_all_saints = True
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (5, 1, u"Día del trabajador"),
-        (10, 12, u"Fiesta nacional de España"),
-        (12, 6, u"Día de la Constitución Española")
+        (5, 1, "Día del trabajador"),
+        (10, 12, "Fiesta nacional de España"),
+        (12, 6, "Día de la Constitución Española")
     )
 
 
@@ -25,6 +27,6 @@ class Catalonia(Spain):
     boxing_day_label = "Sant Esteve"
 
     FIXED_HOLIDAYS = Spain.FIXED_HOLIDAYS + (
-        (6, 24, u"Sant Joan"),
-        (9, 11, u"Diada nacional de Catalunya"),
+        (6, 24, "Sant Joan"),
+        (9, 11, "Diada nacional de Catalunya"),
     )

--- a/workalendar/oceania.py
+++ b/workalendar/oceania.py
@@ -116,12 +116,11 @@ class AustraliaCapitalTerritory(Australia):
         return (day, "Family & Community Day")
 
     def get_variable_days(self, year):
-        days = super(AustraliaCapitalTerritory, self) \
-            .get_variable_days(year)
-        days += [
+        days = super(AustraliaCapitalTerritory, self).get_variable_days(year)
+        days.extend([
             self.get_canberra_day(year),
             self.get_family_community_day(year),
-        ]
+        ])
         return days
 
 
@@ -143,25 +142,22 @@ class AustraliaNorthernTerritory(Australia):
 
     def get_may_day(self, year):
         return (
-            AustraliaNorthernTerritory.get_nth_weekday_in_month(
-                year, 5, MON),
+            AustraliaNorthernTerritory.get_nth_weekday_in_month(year, 5, MON),
             "May Day"
         )
 
     def get_picnic_day(self, year):
         return (
-            AustraliaNorthernTerritory.get_nth_weekday_in_month(
-                year, 8, MON),
+            AustraliaNorthernTerritory.get_nth_weekday_in_month(year, 8, MON),
             "Picnic Day"
         )
 
     def get_variable_days(self, year):
-        days = super(AustraliaNorthernTerritory, self) \
-            .get_variable_days(year)
-        days += [
+        days = super(AustraliaNorthernTerritory, self).get_variable_days(year)
+        days.extend([
             self.get_may_day(year),
             self.get_picnic_day(year),
-        ]
+        ])
         return days
 
 
@@ -173,17 +169,13 @@ class AustraliaQueensland(Australia):
 
     def get_labour_day_may(self, year):
         return (
-            AustraliaNorthernTerritory.get_nth_weekday_in_month(
-                year, 5, MON),
+            AustraliaNorthernTerritory.get_nth_weekday_in_month(year, 5, MON),
             "Labour Day"
         )
 
     def get_variable_days(self, year):
-        days = super(AustraliaQueensland, self) \
-            .get_variable_days(year)
-        days += [
-            self.get_labour_day_may(year),
-        ]
+        days = super(AustraliaQueensland, self).get_variable_days(year)
+        days.append(self.get_labour_day_may(year))
         return days
 
 
@@ -195,8 +187,7 @@ class SouthAustralia(Australia):
 
     def get_adelaides_cup(self, year):
         return (
-            SouthAustralia.get_nth_weekday_in_month(
-                year, 3, MON, 2),
+            SouthAustralia.get_nth_weekday_in_month(year, 3, MON, 2),
             "Adelaide's cup"
         )
 
@@ -204,12 +195,11 @@ class SouthAustralia(Australia):
         return (date(year, 12, 26), "Proclamation Day")
 
     def get_variable_days(self, year):
-        days = super(SouthAustralia, self) \
-            .get_variable_days(year)
-        days += [
+        days = super(SouthAustralia, self).get_variable_days(year)
+        days.extend([
             self.get_adelaides_cup(year),
             self.get_proclamation_day(year),
-        ]
+        ])
         return days
 
 
@@ -307,7 +297,6 @@ class WesternAustralia(Australia):
         # The western Australia territory, since it's based on the Governor
         # Decision (it is typically the last Monday of September or the first
         # Monday of October)
-
         days = super(WesternAustralia, self).get_variable_days(year)
         days.append(self.get_labours_day_in_march(year))
         days.append(self.get_western_australia_day(year))

--- a/workalendar/usa.py
+++ b/workalendar/usa.py
@@ -23,7 +23,7 @@ class UnitedStates(WesternCalendar, ChristianMixin):
     def get_variable_days(self, year):
         # usual variable days
         days = super(UnitedStates, self).get_variable_days(year)
-        days += [
+        days.extend([
             (UnitedStates.get_nth_weekday_in_month(year, 1, MON, 3),
                 'Martin Luther King, Jr. Day'),
 
@@ -41,7 +41,7 @@ class UnitedStates(WesternCalendar, ChristianMixin):
 
             (UnitedStates.get_nth_weekday_in_month(year, 11, THU, 4),
                 "Thanksgiving Day"),
-        ]
+        ])
         # Inauguration day
         if UnitedStates.is_presidential_year(year - 1):
             inauguration_day = date(year, 1, 20)
@@ -111,7 +111,7 @@ class CesarChavezDayMixin(Calendar):
     def get_chavez_day(self, year):
         days = [(date(year, 3, 31), "Cesar Chavez Day")]
         if date(year, 3, 31).weekday() == SUN:
-            days += [(date(year, 4, 1), "Cesar Chavez Day (Observed)")]
+            days.append((date(year, 4, 1), "Cesar Chavez Day (Observed)"))
         return days
 
 
@@ -140,8 +140,9 @@ class PatriotsDayMixin(Calendar):
 class ConfederateMemorialDayMixin(Calendar):
     """4th Monday of April"""
     def get_confederate_day(self, year):
-        return (Alabama.get_nth_weekday_in_month(year, 4, MON, 4),
-                "Confederate Day")
+        day = ConfederateMemorialDayMixin.get_nth_weekday_in_month(
+            year, 4, MON, 4)
+        return (day, "Confederate Day")
 
 
 class ThanksgivingFridayMixin(Calendar):
@@ -155,15 +156,17 @@ class Alabama(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     "Alabama"
     def get_variable_days(self, year):
         days = super(Alabama, self).get_variable_days(year)
-        days = super(Alabama, self).float(days)
-        days = days + [self.get_confederate_day(year)]
-        days = days + [(Alabama.get_nth_weekday_in_month(year, 6, MON, 1),
-                        "Jefferson Davis Birthday")]
+        days = self.float(days)
+        days.extend([
+            self.get_confederate_day(year),
+            (Alabama.get_nth_weekday_in_month(year, 6, MON, 1),
+             "Jefferson Davis Birthday")
+        ])
         return days
 
     def get_fixed_holidays(self, year):
         days = super(Alabama, self).get_fixed_holidays(year)
-        days = super(Alabama, self).float(days, year)
+        days = self.float(days, year)
         return days
 
 
@@ -175,14 +178,15 @@ class Alaska(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin):
 
     def get_variable_days(self, year):
         days = super(Alaska, self).get_variable_days(year)
-        days = super(Alaska, self).float(days)
-        days = days + [(Alabama.get_last_weekday_in_month(year, 3, MON),
-                        "Seward's Day")]
+        days = self.float(days)
+        days.append(
+            (Alabama.get_last_weekday_in_month(year, 3, MON), "Seward's Day")
+        )
         return days
 
     def get_fixed_holidays(self, year):
         days = super(Alaska, self).get_fixed_holidays(year)
-        days = super(Alaska, self).float(days, year)
+        days = self.float(days, year)
         return days
 
 
@@ -190,12 +194,12 @@ class Arizona(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin):
     """Arizona"""
     def get_variable_days(self, year):
         days = super(Arizona, self).get_variable_days(year)
-        days = super(Arizona, self).float(days)
+        days = self.float(days)
         return days
 
     def get_fixed_holidays(self, year):
         days = super(Arizona, self).get_fixed_holidays(year)
-        days = super(Arizona, self).float(days, year)
+        days = self.float(days, year)
         return days
 
 
@@ -210,7 +214,7 @@ class Arkansas(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin):
 
     def get_fixed_holidays(self, year):
         days = super(Arkansas, self).get_fixed_holidays(year)
-        days = super(Arkansas, self).float(days, year)
+        days = self.float(days, year)
         return days
 
 
@@ -219,15 +223,17 @@ class California(UnitedStates, WesternCalendar, ThanksgivingFridayMixin,
     """California"""
     def get_variable_days(self, year):
         days = super(California, self).get_variable_days(year)
-        days += [self.get_thanksgiving_friday(year)]
-        days += [(self.get_nth_weekday_in_month(year, 10, MON, 2),
-                  "Indingenous People's Day")]
-        days += self.get_chavez_day(year)
+        days.extend([
+            self.get_thanksgiving_friday(year),
+            (self.get_nth_weekday_in_month(year, 10, MON, 2),
+             "Indingenous People's Day")
+        ])
+        days.extend(self.get_chavez_day(year))
         return days
 
     def get_fixed_holidays(self, year):
         days = super(California, self).get_fixed_holidays(year)
-        days = super(California, self).float(days, year)
+        days = self.float(days, year)
         return days
 
 
@@ -237,12 +243,12 @@ class Colorado(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
 
     def get_variable_days(self, year):
         days = super(Colorado, self).get_variable_days(year)
-        days += self.get_chavez_day(year)
+        days.extend(self.get_chavez_day(year))
         return days
 
     def get_fixed_holidays(self, year):
         days = super(Colorado, self).get_fixed_holidays(year)
-        days = super(Colorado, self).float(days, year)
+        days = self.float(days, year)
         return days
 
 
@@ -256,12 +262,12 @@ class Connecticut(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin):
 
     def get_variable_days(self, year):
         days = super(Connecticut, self).get_variable_days(year)
-        days = super(Connecticut, self).float(days)
+        days = self.float(days)
         return days
 
     def get_fixed_holidays(self, year):
         days = super(Connecticut, self).get_fixed_holidays(year)
-        days = super(Connecticut, self).float(days, year)
+        days = self.float(days, year)
         return days
 
 
@@ -274,7 +280,7 @@ class Delaware(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Delaware, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
+        days.append(self.get_thanksgiving_friday(year))
         return days
 
     def get_fixed_holidays(self, year):
@@ -287,14 +293,16 @@ class Florida(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin):
     """Florida"""
     def get_variable_days(self, year):
         days = super(Florida, self).get_variable_days(year)
-        days = super(Florida, self).float(days)
-        days = days + [(Florida.get_nth_weekday_in_month(year, 11, FRI, 4),
-                        "Friday after Thanksgiving")]
+        days = self.float(days)
+        days.append(
+            (Florida.get_nth_weekday_in_month(year, 11, FRI, 4),
+             "Friday after Thanksgiving")
+        )
         return days
 
     def get_fixed_holidays(self, year):
         days = super(Florida, self).get_fixed_holidays(year)
-        days = super(Florida, self).float(days, year)
+        days = self.float(days, year)
         return days
 
 
@@ -303,11 +311,13 @@ class Georgia(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     """Georgia"""
     def get_variable_days(self, year):
         days = super(Georgia, self).get_variable_days(year)
-        days = super(Georgia, self).float(days)
-        days += [self.get_confederate_day(year)]
-        days += [(Georgia.get_nth_weekday_in_month(year, 11, FRI, 4),
-                  "Robert E. Lee's Birthday (Observed)")]
-        days += [self.get_washington_birthday(year)]
+        days = self.float(days)
+        days.extend([
+            self.get_confederate_day(year),
+            (Georgia.get_nth_weekday_in_month(year, 11, FRI, 4),
+             "Robert E. Lee's Birthday (Observed)"),
+            self.get_washington_birthday(year)
+        ])
         return days
 
     def get_fixed_holidays(self, year):
@@ -344,7 +354,7 @@ class Illinois(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Illinois, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
+        days.append(self.get_thanksgiving_friday(year))
         return days
 
     def get_fixed_holidays(self, year):
@@ -361,8 +371,10 @@ class Indiana(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Indiana, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_washington_birthday(year)]
-        days += [self.get_thanksgiving_friday(year)]
+        days.extend([
+            self.get_washington_birthday(year),
+            self.get_thanksgiving_friday(year)
+        ])
         return days
 
     def get_fixed_holidays(self, year):
@@ -377,7 +389,7 @@ class Iowa(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Iowa, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
+        days.append(self.get_thanksgiving_friday(year))
         return days
 
     def get_fixed_holidays(self, year):
@@ -394,8 +406,10 @@ class Kansas(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Kansas, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
-        days += [self.get_day_after_christmas(year)]
+        days.extend([
+            self.get_thanksgiving_friday(year),
+            self.get_day_after_christmas(year)
+        ])
         return days
 
     def get_fixed_holidays(self, year):
@@ -412,8 +426,10 @@ class Kentucky(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Kentucky, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
-        days += [self.get_day_after_christmas(year)]
+        days.extend([
+            self.get_thanksgiving_friday(year),
+            self.get_day_after_christmas(year)
+        ])
         return days
 
     def get_fixed_holidays(self, year):
@@ -430,7 +446,7 @@ class Louisiana(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Louisiana, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_mardis_gras(year)]
+        days.append(self.get_mardis_gras(year))
         return days
 
     def get_fixed_holidays(self, year):
@@ -446,8 +462,10 @@ class Maine(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Maine, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_patriots_day(year)]
-        days += [self.get_thanksgiving_friday(year)]
+        days.extend([
+            self.get_patriots_day(year),
+            self.get_thanksgiving_friday(year)
+        ])
         return days
 
     def get_fixed_holidays(self, year):
@@ -462,7 +480,7 @@ class Maryland(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Maryland, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
+        days.append(self.get_thanksgiving_friday(year))
         return days
 
     def get_fixed_holidays(self, year):
@@ -477,7 +495,7 @@ class Massachusetts(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Massachusetts, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_patriots_day(year)]
+        days.append(self.get_patriots_day(year))
         return days
 
     def get_fixed_holidays(self, year):
@@ -494,12 +512,12 @@ class Michigan(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Michigan, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
+        days.append(self.get_thanksgiving_friday(year))
         return days
 
     def get_fixed_holidays(self, year):
         days = super(Michigan, self).get_fixed_holidays(year)
-        days += [(date(year, 12, 31), "New Years Eve")]
+        days.append((date(year, 12, 31), "New Years Eve"))
         days = self.float(days, year)
         return days
 
@@ -510,7 +528,7 @@ class Minnesota(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Minnesota, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
+        days.append(self.get_thanksgiving_friday(year))
         return days
 
     def get_fixed_holidays(self, year):
@@ -525,8 +543,10 @@ class Mississippi(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Mississippi, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_confederate_day(year)]
-        days += [self.get_thanksgiving_friday(year)]
+        days.extend([
+            self.get_confederate_day(year),
+            self.get_thanksgiving_friday(year)
+        ])
         return days
 
     def get_fixed_holidays(self, year):
@@ -573,9 +593,10 @@ class Nebraska(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Nebraska, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
-        days += [(self.get_last_weekday_in_month(year, 4, FRI),
-                  "Arbor Day")]
+        days.extend([
+            self.get_thanksgiving_friday(year),
+            (self.get_last_weekday_in_month(year, 4, FRI), "Arbor Day")
+        ])
         return days
 
     def get_fixed_holidays(self, year):
@@ -590,9 +611,10 @@ class Nevada(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Nevada, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
-        days += [(self.get_last_weekday_in_month(year, 10, FRI),
-                  "Nevada Day")]
+        days.extend([
+            self.get_thanksgiving_friday(year),
+            (self.get_last_weekday_in_month(year, 10, FRI), "Nevada Day")
+        ])
         return days
 
     def get_fixed_holidays(self, year):
@@ -603,11 +625,11 @@ class Nevada(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
 
 class NewHampshire(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
                    ThanksgivingFridayMixin):
-    """NewHampshire"""
+    """New Hampshire"""
     def get_variable_days(self, year):
         days = super(NewHampshire, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
+        days.append(self.get_thanksgiving_friday(year))
         return days
 
     def get_fixed_holidays(self, year):
@@ -617,7 +639,7 @@ class NewHampshire(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
 
 
 class NewJersey(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin):
-    """NewJersey"""
+    """New Jersey"""
     include_good_friday = True
 
     def get_variable_days(self, year):
@@ -633,11 +655,11 @@ class NewJersey(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin):
 
 class NewMexico(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
                 ThanksgivingFridayMixin):
-    """NewMexico"""
+    """New Mexico"""
     def get_variable_days(self, year):
         days = super(NewMexico, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
+        days.append(self.get_thanksgiving_friday(year))
         return days
 
     def get_fixed_holidays(self, year):
@@ -647,7 +669,7 @@ class NewMexico(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
 
 
 class NewYork(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin):
-    """NewYork"""
+    """New York"""
     FIXED_HOLIDAYS = UnitedStates.FIXED_HOLIDAYS + (
         (2, 12, "Lincoln's Birthday"),
     )
@@ -665,15 +687,17 @@ class NewYork(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin):
 
 class NorthCarolina(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
                     ThanksgivingFridayMixin, DayAfterChristmasNoFloatMixin):
-    """NorthCarolina"""
+    """North Carolina"""
     include_good_friday = True
     include_christmas_eve = True
 
     def get_variable_days(self, year):
         days = super(NorthCarolina, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
-        days += [self.get_day_after_christmas(year)]
+        days.extend([
+            self.get_thanksgiving_friday(year),
+            self.get_day_after_christmas(year)
+        ])
         return days
 
     def get_fixed_holidays(self, year):
@@ -683,7 +707,7 @@ class NorthCarolina(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
 
 
 class NorthDakota(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin):
-    """NorthDakota"""
+    """North Dakota"""
     include_good_friday = True
 
     def get_variable_days(self, year):
@@ -722,7 +746,7 @@ class Oklahoma(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Oklahoma, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
+        days.append(self.get_thanksgiving_friday(year))
         return days
 
     def get_fixed_holidays(self, year):
@@ -753,7 +777,7 @@ class Pennsylvania(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Pennsylvania, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
+        days.append(self.get_thanksgiving_friday(year))
         return days
 
     def get_fixed_holidays(self, year):
@@ -763,13 +787,13 @@ class Pennsylvania(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
 
 
 class RhodeIsland(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin):
-    """RhodeIsland"""
+    """Rhode Island"""
 
     def get_variable_days(self, year):
         days = super(RhodeIsland, self).get_variable_days(year)
         days = self.float(days)
-        days += [(self.get_nth_weekday_in_month(year, 8, MON, 2),
-                  "Victory Day")]
+        days.append(
+            (self.get_nth_weekday_in_month(year, 8, MON, 2), "Victory Day"))
         return days
 
     def get_fixed_holidays(self, year):
@@ -780,7 +804,7 @@ class RhodeIsland(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin):
 
 class SouthCarolina(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
                     ThanksgivingFridayMixin, DayAfterChristmasNoFloatMixin):
-    """SouthCarolina"""
+    """South Carolina"""
     FIXED_HOLIDAYS = UnitedStates.FIXED_HOLIDAYS + (
         (5, 10, "Confederate Memorial Day"),
     )
@@ -790,8 +814,10 @@ class SouthCarolina(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(SouthCarolina, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
-        days += [self.get_day_after_christmas(year)]
+        days.extend([
+            self.get_thanksgiving_friday(year),
+            self.get_day_after_christmas(year)
+        ])
         return days
 
     def get_fixed_holidays(self, year):
@@ -801,7 +827,7 @@ class SouthCarolina(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
 
 
 class SouthDakota(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin):
-    """SouthDakota"""
+    """South Dakota"""
     def get_variable_days(self, year):
         days = super(SouthDakota, self).get_variable_days(year)
         days = self.float(days)
@@ -821,7 +847,7 @@ class Tennessee(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Tennessee, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
+        days.append(self.get_thanksgiving_friday(year))
         return days
 
     def get_fixed_holidays(self, year):
@@ -838,17 +864,19 @@ class Texas(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Texas, self).get_variable_days(year)
         days = self.float(days)
-        days += self.get_chavez_day(year)
+        days.extend(self.get_chavez_day(year))
         return days
 
     def get_fixed_holidays(self, year):
         days = super(Texas, self).get_fixed_holidays(year)
         days = self.float(days, year)
-        days += [(date(year, 1, 19), "Confederate Heroes Day")]
-        days += [(date(year, 3, 2), "Texas Independence Day")]
-        days += [(date(year, 4, 21), "San Jacinto Day")]
-        days += [(date(year, 6, 19), "Emancipation Day")]
-        days += [(date(year, 8, 27), "Lyndon B. Jonhson Day")]
+        days.extend([
+            (date(year, 1, 19), "Confederate Heroes Day"),
+            (date(year, 3, 2), "Texas Independence Day"),
+            (date(year, 4, 21), "San Jacinto Day"),
+            (date(year, 6, 19), "Emancipation Day"),
+            (date(year, 8, 27), "Lyndon B. Jonhson Day")
+        ])
         return days
 
 
@@ -878,8 +906,10 @@ class Vermont(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin):
     def get_variable_days(self, year):
         days = super(Vermont, self).get_variable_days(year)
         days = self.float(days)
-        days += [(self.get_nth_weekday_in_month(year, 3, TUE, 1),
-                  "Town Meeting Day")]
+        days.append(
+            (self.get_nth_weekday_in_month(year, 3, TUE, 1),
+             "Town Meeting Day")
+        )
         return days
 
     def get_fixed_holidays(self, year):
@@ -896,11 +926,13 @@ class Virginia(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Virginia, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
-        days += [(self.get_nth_weekday_in_month(year, 1, FRI, 3),
-                  "Lee-Jackson Day")]
-        days += [(self.get_nth_weekday_in_month(year, 11, WED, 4),
-                  "Additional Thanksgiving Holiday")]
+        days.extend([
+            self.get_thanksgiving_friday(year),
+            (self.get_nth_weekday_in_month(year, 1, FRI, 3),
+             "Lee-Jackson Day"),
+            (self.get_nth_weekday_in_month(year, 11, WED, 4),
+             "Additional Thanksgiving Holiday")
+        ])
         return days
 
     def get_fixed_holidays(self, year):
@@ -916,7 +948,7 @@ class Washington(UnitedStates, WesternCalendar, ThanksgivingFridayMixin,
     def get_variable_days(self, year):
         days = super(Washington, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
+        days.append(self.get_thanksgiving_friday(year))
         return days
 
     def get_fixed_holidays(self, year):
@@ -927,23 +959,24 @@ class Washington(UnitedStates, WesternCalendar, ThanksgivingFridayMixin,
 
 class WestVirginia(UnitedStates, WesternCalendar, ThanksgivingFridayMixin,
                    FloatToNearestWeekdayMixin):
-    """WestVirginia"""
+    """West Virginia"""
     include_christmas_eve = True
 
     def get_variable_days(self, year):
         days = super(WestVirginia, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
-        days += [(date(year, 6, 20), "West Virgina Day")]
+        days.extend([
+            self.get_thanksgiving_friday(year),
+            (date(year, 6, 20), "West Virgina Day")
+        ])
         if date(year, 6, 20).weekday() == SUN:
-            days += [(date(year, 6, 21), "West Virgina Day (Observed)")]
-
+            days.append((date(year, 6, 21), "West Virgina Day (Observed)"))
         return days
 
     def get_fixed_holidays(self, year):
         days = super(WestVirginia, self).get_fixed_holidays(year)
         days = self.float(days, year)
-        days += [(date(year, 12, 31), "New Years Eve")]
+        days.append((date(year, 12, 31), "New Years Eve"))
         return days
 
 
@@ -955,12 +988,12 @@ class Wisconsin(UnitedStates, WesternCalendar, FloatToNearestWeekdayMixin,
     def get_variable_days(self, year):
         days = super(Wisconsin, self).get_variable_days(year)
         days = self.float(days)
-        days += [self.get_thanksgiving_friday(year)]
+        days.append(self.get_thanksgiving_friday(year))
         return days
 
     def get_fixed_holidays(self, year):
         days = super(Wisconsin, self).get_fixed_holidays(year)
-        days += [(date(year, 12, 31), "New Years Eve")]
+        days.append((date(year, 12, 31), "New Years Eve"))
         days = self.float(days, year)
         return days
 


### PR DESCRIPTION

* Hungary: a more clever take on the Good Friday rule
* Iceland: using ``extend`` instead of ``+=``
* Ireland: a more clever take on Whit Monday rule
* Latvia: using ``extend`` for lists, instead of ``+=``
* Netherlands: using ``.append`` for just *one* day to add
* Spain: remove the ugly ``u''``
* Japan: readability changes
* Taiwan: using ``extend`` for lists, instead of ``+=``
* Canada: using ``extend`` and ``append`` for lists
* Australia: using ``extend`` instead of ``+=`` + minor code reflow
* USA: using ``extend`` and ``append`` when needed, fixed a few docstrings, removed unnecessary 'super' calls
