### PR TITLE
Alabama Counties

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ master (unreleased)
 -------------------
 
 - Splitted `africa.py` file into an `africa/` module (#236).
+- Added Alabama Counties - Baldwin County, Mobile County, Perry County. Refactored UnitedStates classes to have a parameter to include the "Mardi Gras" day (#214).
 
 2.0.0 (2017-06-23)
 ------------------

--- a/workalendar/tests/test_usa.py
+++ b/workalendar/tests/test_usa.py
@@ -3,7 +3,9 @@ from unittest import skip
 from datetime import date
 from workalendar.tests import GenericCalendarTest
 from workalendar.usa import (
-    UnitedStates, Alabama, Florida, Arkansas, Alaska, Arizona, California,
+    UnitedStates,
+    Alabama, AlabamaBaldwinCounty, AlabamaMobileCounty, AlabamaPerryCounty,
+    Florida, Arkansas, Alaska, Arizona, California,
     Colorado, Connecticut, Delaware, DistrictOfColumbia, Georgia, Hawaii,
     Indiana, Illinois, Idaho, Iowa, Kansas, Kentucky, Louisiana, Maine,
     Maryland, Massachusetts, Minnesota, Michigan, Mississippi, Missouri,
@@ -183,6 +185,12 @@ class UnitedStatesTest(GenericCalendarTest):
         _, label = self.cal.get_veterans_day(2017)
         self.assertEqual(label, "Veterans Day")
 
+    def test_mardi_gras(self):
+        year = 2017
+        day, _ = self.cal.get_mardi_gras(year)
+        holidays = self.cal.holidays_set(year)
+        self.assertNotIn(day, holidays)
+
 
 class NoColumbus(object):
     """
@@ -282,6 +290,17 @@ class ElectionDayEveryYear(object):
             self.assertIn(self.cal.get_election_date(year), holidays)
 
 
+class IncludeMardiGras(object):
+    """
+    Louisiana and some areas (Alabama Counties) include Mardi Gras
+    """
+    def test_mardi_gras(self):
+        year = 2017
+        day, _ = self.cal.get_mardi_gras(year)
+        holidays = self.cal.holidays_set(year)
+        self.assertIn(day, holidays)
+
+
 class AlabamaTest(UnitedStatesTest):
     cal_class = Alabama
 
@@ -314,6 +333,22 @@ class AlabamaTest(UnitedStatesTest):
         holidays = self.cal.holidays_set(2015)
         self.assertIn(date(2015, 4, 27), holidays)  # Confederate Memorial Day
         self.assertIn(date(2015, 6, 1), holidays)  # Jefferson Davis' birthday
+
+
+class AlabamaBaldwinCountyTest(IncludeMardiGras, AlabamaTest):
+    cal_class = AlabamaBaldwinCounty
+
+
+class AlabamaMobileCountyTest(IncludeMardiGras, AlabamaTest):
+    cal_class = AlabamaMobileCounty
+
+
+class AlabamaPerryCountyTest(AlabamaTest):
+    cal_class = AlabamaPerryCounty
+
+    def test_county_year_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 11, 13), holidays)  # Obama Day
 
 
 class AlaskaTest(NoColumbus, UnitedStatesTest):
@@ -676,17 +711,16 @@ class KentuckyTest(NoPresidentialDay, NoColumbus, UnitedStatesTest):
         self.assertIn(date(2015, 12, 31), holidays)  # NY Eve
 
 
-class LouisianaTest(NoColumbus, ElectionDayEvenYears, UnitedStatesTest):
+class LouisianaTest(IncludeMardiGras, NoColumbus, ElectionDayEvenYears,
+                    UnitedStatesTest):
     cal_class = Louisiana
 
     def test_state_year_2014(self):
         holidays = self.cal.holidays_set(2014)
-        self.assertIn(date(2014, 3, 4), holidays)  # Mardi Gras
         self.assertIn(date(2014, 4, 18), holidays)  # Good Friday
 
     def test_state_year_2015(self):
         holidays = self.cal.holidays_set(2015)
-        self.assertIn(date(2015, 2, 17), holidays)  # Mardi Gras
         self.assertIn(date(2015, 4, 3), holidays)  # Good Friday
 
 

--- a/workalendar/usa/__init__.py
+++ b/workalendar/usa/__init__.py
@@ -4,7 +4,8 @@ from __future__ import (absolute_import, division, print_function,
 
 from .core import UnitedStates
 
-from .alabama import Alabama
+from .alabama import (
+    Alabama, AlabamaBaldwinCounty, AlabamaMobileCounty, AlabamaPerryCounty)
 from .alaska import Alaska
 from .arizona import Arizona
 from .arkansas import Arkansas
@@ -60,7 +61,7 @@ NONE, NEAREST_WEEKDAY, MONDAY = range(3)
 
 __all__ = [
     UnitedStates,  # Generic federal calendar
-    Alabama,
+    Alabama, AlabamaBaldwinCounty, AlabamaMobileCounty, AlabamaPerryCounty,
     Alaska,
     Arizona,
     Arkansas,

--- a/workalendar/usa/alabama.py
+++ b/workalendar/usa/alabama.py
@@ -27,3 +27,31 @@ class Alabama(UnitedStates):
         days = super(Alabama, self).get_variable_days(year)
         days.append(self.get_jefferson_davis_birthday(year))
         return days
+
+
+class AlabamaBaldwinCounty(Alabama):
+    "Baldwin County, Alabama"
+    include_mardi_gras = True
+
+
+class AlabamaMobileCounty(Alabama):
+    "Mobile County, Alabama"
+    include_mardi_gras = True
+
+
+class AlabamaPerryCounty(Alabama):
+    "Mobile Perry, Alabama"
+
+    def get_obama_day(self, year):
+        """
+        Obama Day happens on the 2nd MON of November.
+        """
+        return (
+            self.get_nth_weekday_in_month(year, 11, MON, 2),
+            "Obama Day"
+        )
+
+    def get_variable_days(self, year):
+        days = super(AlabamaPerryCounty, self).get_variable_days(year)
+        days.append(self.get_obama_day(year))
+        return days

--- a/workalendar/usa/core.py
+++ b/workalendar/usa/core.py
@@ -56,6 +56,9 @@ class UnitedStates(WesternCalendar, ChristianMixin):
     # National Memorial Day
     national_memorial_day_label = "Memorial Day"
 
+    # Some regional variants
+    include_mardi_gras = False
+
     # Shift day mechanism
     # These days won't be shifted to next MON or previous FRI
     shift_exceptions = (
@@ -251,6 +254,13 @@ class UnitedStates(WesternCalendar, ChristianMixin):
             self.national_memorial_day_label
         )
 
+    def get_mardi_gras(self, year):
+        """
+        Mardi Gras is the Tuesday happening 47 days before Easter
+        """
+        sunday = self.get_easter_sunday(year)
+        return (sunday - timedelta(days=47), "Mardi Gras")
+
     def get_variable_days(self, year):
         # usual variable days
         days = super(UnitedStates, self).get_variable_days(year)
@@ -266,6 +276,9 @@ class UnitedStates(WesternCalendar, ChristianMixin):
             (UnitedStates.get_nth_weekday_in_month(year, 11, THU, 4),
                 "Thanksgiving Day"),
         ])
+
+        if self.include_mardi_gras:
+            days.append(self.get_mardi_gras(year))
 
         if self.include_federal_presidents_day:
             days.append(self.get_presidents_day(year))
@@ -302,6 +315,7 @@ class UnitedStates(WesternCalendar, ChristianMixin):
             days.append(
                 self.get_thanksgiving_friday(year)
             )
+
         return days
 
     def get_veterans_day(self, year):

--- a/workalendar/usa/louisiana.py
+++ b/workalendar/usa/louisiana.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from datetime import timedelta
 from .core import UnitedStates
 
 
@@ -11,12 +10,4 @@ class Louisiana(UnitedStates):
     include_good_friday = True
     include_election_day_even = True
     include_columbus_day = False
-
-    def get_mardi_gras(self, year):
-        sunday = self.get_easter_sunday(year)
-        return (sunday - timedelta(days=47), "Mardi Gras")
-
-    def get_variable_days(self, year):
-        days = super(Louisiana, self).get_variable_days(year)
-        days.append(self.get_mardi_gras(year))
-        return days
+    include_mardi_gras = True


### PR DESCRIPTION
There are 3 Counties with specific holidays in Alabama:

* Baldwin County,
* Mobile County,
* Perry County

https://en.wikipedia.org/wiki/Public_holidays_in_the_United_States#Baldwin_County.2C_Alabama

Requires the #171 to be solved