### PR TITLE
Remove support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python: 2.7
 env:
     - TOX_ENV=py27
-    - TOX_ENV=py33
     - TOX_ENV=py34
     - TOX_ENV=py35
     - TOX_ENV=flake8

--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,9 @@ params = dict(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,flake8,py33,py34,py35,py36
+envlist = py27,flake8,py34,py35,py36
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.3 is buggy and not supported anymore, also Travis-CI removed the interpreter which makes tests to fail.