### PR TITLE
Australia Holidays

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,9 @@ master (unreleased)
 
 - Dropped support for Python 3.3 (#245).
 - Fixed Travis-ci configuration for Python 3.5 and al (#252).
+- Fixed shifting ANZAC day for Australia states(#249)
+- Renamed Australian state classes to actual state names(eg. AustraliaNewSouthWales to NewSouthWales)
+- Update ACT holidays(#251)
 
 2.3.1 (2017-07-27)
 ------------------

--- a/workalendar/oceania.py
+++ b/workalendar/oceania.py
@@ -96,6 +96,10 @@ class AustralianCapitalTerritory(Australia):
 
         # Family & Community Day was celebrated on the first Tuesday of
         # November in 2007, 2008 and 2009
+
+        # Per Holidays (Reconciliation Day) Amendment Bill 2017, 2017 is the
+        # last year that ACT will celebrate family and community day. It is
+        # being replaced by Reconciliaton day
         if year in (2007, 2008, 2009):
             day = AustralianCapitalTerritory.get_nth_weekday_in_month(
                 year, 11, TUE)
@@ -113,16 +117,33 @@ class AustralianCapitalTerritory(Australia):
             day = date(2015, 9, 28)
         elif year == 2016:
             day = date(2016, 9, 26)
+        elif year == 2017:
+            day = date(2017, 9, 25)
         else:
-            raise Exception("Year %d is not implemented, Sorry" % year)
+            return None
         return (day, "Family & Community Day")
+
+    def get_reconciliation_day(self, year):
+        if year >= 2018:
+            reconciliation_day = date(year, 5, 27)
+            if reconciliation_day.weekday() == MON:
+                return (reconciliation_day, "Reconciliation Day")
+            else:
+                shift = AustralianCapitalTerritory.get_first_weekday_after(reconciliation_day, MON)
+                return shift, "Reconciliation Day Shift"
 
     def get_variable_days(self, year):
         days = super(AustralianCapitalTerritory, self).get_variable_days(year)
-        days.extend([
-            self.get_canberra_day(year),
-            self.get_family_community_day(year),
-        ])
+        days.append(self.get_canberra_day(year))
+
+        family_community_day = self.get_family_community_day(year)
+        if family_community_day is not None:
+            days.append(family_community_day)
+
+        reconciliation_day = self.get_reconciliation_day(year)
+        if reconciliation_day is not None:
+            days.append(reconciliation_day)
+
         return days
 
 

--- a/workalendar/oceania.py
+++ b/workalendar/oceania.py
@@ -1,5 +1,5 @@
 from workalendar.core import WesternCalendar, ChristianMixin
-from workalendar.core import MON, TUE, FRI
+from workalendar.core import MON, TUE, FRI, SAT, SUN
 from datetime import date, timedelta
 
 
@@ -12,6 +12,8 @@ class Australia(WesternCalendar, ChristianMixin):
     include_boxing_day = True
     # Shall we shift Anzac Day?
     shift_anzac_day = True
+
+    ANZAC_SHIFT_DAYS = (SAT, SUN)
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (1, 26, "Australia Day"),
@@ -39,7 +41,7 @@ class Australia(WesternCalendar, ChristianMixin):
         anzac_day = date(year, 4, 25)
         if not self.shift_anzac_day:
             return (anzac_day, "Anzac Day")
-        if anzac_day.weekday() in self.get_weekend_days():
+        if anzac_day.weekday() in self.ANZAC_SHIFT_DAYS:
             anzac_day = self.find_following_working_day(anzac_day)
         return (anzac_day, "Anzac Day")
 
@@ -81,8 +83,8 @@ class Australia(WesternCalendar, ChristianMixin):
         return days
 
 
-class AustraliaCapitalTerritory(Australia):
-    "Australia Capital Territory"
+class AustralianCapitalTerritory(Australia):
+    "Australian Capital Territory"
     include_easter_saturday = True
     include_queens_birthday = True
     include_labour_day_october = True
@@ -95,7 +97,7 @@ class AustraliaCapitalTerritory(Australia):
         # Family & Community Day was celebrated on the first Tuesday of
         # November in 2007, 2008 and 2009
         if year in (2007, 2008, 2009):
-            day = AustraliaCapitalTerritory.get_nth_weekday_in_month(
+            day = AustralianCapitalTerritory.get_nth_weekday_in_month(
                 year, 11, TUE)
         elif year == 2010:
             day = date(2010, 9, 27)
@@ -116,7 +118,7 @@ class AustraliaCapitalTerritory(Australia):
         return (day, "Family & Community Day")
 
     def get_variable_days(self, year):
-        days = super(AustraliaCapitalTerritory, self).get_variable_days(year)
+        days = super(AustralianCapitalTerritory, self).get_variable_days(year)
         days.extend([
             self.get_canberra_day(year),
             self.get_family_community_day(year),
@@ -124,36 +126,39 @@ class AustraliaCapitalTerritory(Australia):
         return days
 
 
-class AustraliaNewSouthWales(Australia):
-    "Australia New South Wales"
+class NewSouthWales(Australia):
+    "New South Wales"
     include_queens_birthday = True
     include_easter_saturday = True
     include_easter_sunday = True
     include_labour_day_october = True
     include_boxing_day = True
-    shift_anzac_day = False
+
+    ANZAC_SHIFT_DAYS = (SUN,)
 
 
-class AustraliaNorthernTerritory(Australia):
-    "Australia Northern Territory"
+class NorthernTerritory(Australia):
+    "Northern Territory"
     include_easter_saturday = True
     include_queens_birthday = True
     include_boxing_day = True
 
+    ANZAC_SHIFT_DAYS = (SUN,)
+
     def get_may_day(self, year):
         return (
-            AustraliaNorthernTerritory.get_nth_weekday_in_month(year, 5, MON),
+            NorthernTerritory.get_nth_weekday_in_month(year, 5, MON),
             "May Day"
         )
 
     def get_picnic_day(self, year):
         return (
-            AustraliaNorthernTerritory.get_nth_weekday_in_month(year, 8, MON),
+            NorthernTerritory.get_nth_weekday_in_month(year, 8, MON),
             "Picnic Day"
         )
 
     def get_variable_days(self, year):
-        days = super(AustraliaNorthernTerritory, self).get_variable_days(year)
+        days = super(NorthernTerritory, self).get_variable_days(year)
         days.extend([
             self.get_may_day(year),
             self.get_picnic_day(year),
@@ -161,20 +166,22 @@ class AustraliaNorthernTerritory(Australia):
         return days
 
 
-class AustraliaQueensland(Australia):
-    "Australia Queensland"
+class Queensland(Australia):
+    "Queensland"
     include_easter_saturday = True
     include_queens_birthday = True
     include_boxing_day = True
 
+    ANZAC_SHIFT_DAYS = (SUN,)
+
     def get_labour_day_may(self, year):
         return (
-            AustraliaNorthernTerritory.get_nth_weekday_in_month(year, 5, MON),
+            Queensland.get_nth_weekday_in_month(year, 5, MON),
             "Labour Day"
         )
 
     def get_variable_days(self, year):
-        days = super(AustraliaQueensland, self).get_variable_days(year)
+        days = super(Queensland, self).get_variable_days(year)
         days.append(self.get_labour_day_may(year))
         return days
 
@@ -184,6 +191,8 @@ class SouthAustralia(Australia):
     include_easter_saturday = True
     include_queens_birthday = True
     include_labour_day_october = True
+
+    ANZAC_SHIFT_DAYS = (SUN,)
 
     def get_adelaides_cup(self, year):
         return (
@@ -256,6 +265,7 @@ class Victoria(Australia):
     include_easter_saturday = True
     include_queens_birthday = True
     include_boxing_day = True
+    shift_anzac_day = False
 
     def get_labours_day_in_march(self, year):
         return (

--- a/workalendar/oceania.py
+++ b/workalendar/oceania.py
@@ -129,7 +129,8 @@ class AustralianCapitalTerritory(Australia):
             if reconciliation_day.weekday() == MON:
                 return (reconciliation_day, "Reconciliation Day")
             else:
-                shift = AustralianCapitalTerritory.get_first_weekday_after(reconciliation_day, MON)
+                shift = AustralianCapitalTerritory.get_first_weekday_after(
+                    reconciliation_day, MON)
                 return shift, "Reconciliation Day Shift"
 
     def get_variable_days(self, year):

--- a/workalendar/tests/test_oceania.py
+++ b/workalendar/tests/test_oceania.py
@@ -1,16 +1,19 @@
 from datetime import date
 
 from workalendar.tests import GenericCalendarTest
-from workalendar.oceania import Australia
-from workalendar.oceania import AustraliaCapitalTerritory
-from workalendar.oceania import AustraliaNewSouthWales
-from workalendar.oceania import AustraliaNorthernTerritory
-from workalendar.oceania import AustraliaQueensland
-from workalendar.oceania import SouthAustralia
-from workalendar.oceania import Tasmania, Hobart
-from workalendar.oceania import Victoria
-from workalendar.oceania import WesternAustralia
-from workalendar.oceania import MarshallIslands
+from workalendar.oceania import (
+    Australia,
+    AustralianCapitalTerritory,
+    NewSouthWales,
+    NorthernTerritory,
+    Queensland,
+    SouthAustralia,
+    Tasmania,
+    Hobart,
+    Victoria,
+    WesternAustralia,
+    MarshallIslands,
+)
 
 
 class AustraliaTest(GenericCalendarTest):
@@ -51,7 +54,7 @@ class AustraliaTest(GenericCalendarTest):
 
 
 class AustraliaCapitalTerritoryTest(AustraliaTest):
-    cal_class = AustraliaCapitalTerritory
+    cal_class = AustralianCapitalTerritory
 
     def test_regional_specific_2013(self):
         holidays = self.cal.holidays_set(2013)
@@ -64,8 +67,8 @@ class AustraliaCapitalTerritoryTest(AustraliaTest):
         self.assertIn(date(2013, 12, 26), holidays)  # Boxing day
 
 
-class AustraliaNewSouthWalesTest(AustraliaTest):
-    cal_class = AustraliaNewSouthWales
+class NewSouthWalesTest(AustraliaTest):
+    cal_class = NewSouthWales
 
     def test_regional_specific_2013(self):
         holidays = self.cal.holidays_set(2013)
@@ -76,13 +79,16 @@ class AustraliaNewSouthWalesTest(AustraliaTest):
         self.assertIn(date(2013, 12, 26), holidays)  # Boxing day
 
     def test_anzac_shift(self):
-        # We don't shift
         holidays = self.cal.holidays_set(2010)
-        self.assertNotIn(date(2010, 4, 26), holidays)
+        self.assertIn(date(2010, 4, 26), holidays)
+
+        # We don't shift if ANZAC day falls on a Saturday
+        holidays = self.cal.holidays_set(2015)
+        self.assertIn(date(2015, 4, 25), holidays)
 
 
-class AustraliaNorthernTerritoryTest(AustraliaTest):
-    cal_class = AustraliaNorthernTerritory
+class NorthernTerritoryTest(AustraliaTest):
+    cal_class = NorthernTerritory
 
     def test_regional_specific_2013(self):
         holidays = self.cal.holidays_set(2013)
@@ -92,9 +98,17 @@ class AustraliaNorthernTerritoryTest(AustraliaTest):
         self.assertIn(date(2013, 8, 5), holidays)  # Picnic day
         self.assertIn(date(2013, 12, 26), holidays)  # Boxing day
 
+    def test_anzac_shift(self):
+        holidays = self.cal.holidays_set(2010)
+        self.assertIn(date(2010, 4, 26), holidays)
 
-class AustraliaQueenslandTest(AustraliaTest):
-    cal_class = AustraliaQueensland
+        # We don't shift if ANZAC day falls on a Saturday
+        holidays = self.cal.holidays_set(2015)
+        self.assertIn(date(2015, 4, 25), holidays)
+
+
+class QueenslandTest(AustraliaTest):
+    cal_class = Queensland
 
     def test_regional_specific_2013(self):
         holidays = self.cal.holidays_set(2013)
@@ -102,6 +116,14 @@ class AustraliaQueenslandTest(AustraliaTest):
         self.assertIn(date(2013, 5, 6), holidays)  # May's labour day
         self.assertIn(date(2013, 6, 10), holidays)  # Queen's Bday
         self.assertIn(date(2013, 12, 26), holidays)  # Boxing day
+
+    def test_anzac_shift(self):
+        holidays = self.cal.holidays_set(2010)
+        self.assertIn(date(2010, 4, 26), holidays)
+
+        # We don't shift if ANZAC day falls on a Saturday
+        holidays = self.cal.holidays_set(2015)
+        self.assertIn(date(2015, 4, 25), holidays)
 
 
 class SouthAustraliaTest(AustraliaTest):
@@ -115,6 +137,14 @@ class SouthAustraliaTest(AustraliaTest):
         self.assertIn(date(2013, 10, 7), holidays)  # Labour day october
         self.assertIn(date(2013, 12, 26), holidays)  # Proclamation day
 
+    def test_anzac_shift(self):
+        holidays = self.cal.holidays_set(2010)
+        self.assertIn(date(2010, 4, 26), holidays)
+
+        # We don't shift if ANZAC day falls on a Saturday
+        holidays = self.cal.holidays_set(2015)
+        self.assertIn(date(2015, 4, 25), holidays)
+
 
 class TasmaniaTest(AustraliaTest):
     cal_class = Tasmania
@@ -124,6 +154,7 @@ class TasmaniaTest(AustraliaTest):
         self.assertIn(date(2013, 3, 11), holidays)  # Eight hours day
         self.assertIn(date(2013, 6, 10), holidays)  # Queen's Bday
         self.assertIn(date(2013, 12, 26), holidays)  # Boxing day
+        self.assertIn(date(2013, 4, 25), holidays)  # ANZAC day
 
     def test_anzac_shift(self):
         # We don't shift
@@ -157,6 +188,12 @@ class VictoriaTest(AustraliaTest):
         self.assertIn(date(2013, 6, 10), holidays)  # Queen's Bday
         self.assertIn(date(2013, 11, 5), holidays)  # Melbourne's cup
         self.assertIn(date(2013, 12, 26), holidays)  # Boxing day
+        self.assertIn(date(2013, 4, 25), holidays)  # ANZAC day
+
+    def test_anzac_shift(self):
+        # We don't shift
+        holidays = self.cal.holidays_set(2010)
+        self.assertNotIn(date(2010, 4, 26), holidays)
 
 
 class WesternAustraliaTest(AustraliaTest):

--- a/workalendar/tests/test_oceania.py
+++ b/workalendar/tests/test_oceania.py
@@ -66,6 +66,16 @@ class AustraliaCapitalTerritoryTest(AustraliaTest):
         self.assertIn(date(2013, 10, 7), holidays)  # Labour day october
         self.assertIn(date(2013, 12, 26), holidays)  # Boxing day
 
+    def test_reconciliation_day(self):
+        reconciliation_day = self.cal.get_reconciliation_day(2017)
+        self.assertIsNone(reconciliation_day)
+
+        reconciliation_day = self.cal.get_reconciliation_day(2018)
+        self.assertEqual(reconciliation_day, (date(2018, 5, 28), "Reconciliation Day Shift"))
+
+        reconciliation_day = self.cal.get_reconciliation_day(2019)
+        self.assertEqual(reconciliation_day, (date(2019, 5, 27), "Reconciliation Day"))
+
 
 class NewSouthWalesTest(AustraliaTest):
     cal_class = NewSouthWales

--- a/workalendar/tests/test_oceania.py
+++ b/workalendar/tests/test_oceania.py
@@ -71,10 +71,12 @@ class AustraliaCapitalTerritoryTest(AustraliaTest):
         self.assertIsNone(reconciliation_day)
 
         reconciliation_day = self.cal.get_reconciliation_day(2018)
-        self.assertEqual(reconciliation_day, (date(2018, 5, 28), "Reconciliation Day Shift"))
+        self.assertEqual(reconciliation_day, (date(2018, 5, 28),
+                                              "Reconciliation Day Shift"))
 
         reconciliation_day = self.cal.get_reconciliation_day(2019)
-        self.assertEqual(reconciliation_day, (date(2019, 5, 27), "Reconciliation Day"))
+        self.assertEqual(reconciliation_day, (date(2019, 5, 27),
+                                              "Reconciliation Day"))
 
 
 class NewSouthWalesTest(AustraliaTest):


### PR DESCRIPTION
- [ X] Tests with a significant number of years to be tested for your calendar.
- [ X] Changelog amended with a mention describing your changes.

This is a fix for the following:
- ANZAC day shifting for each state in Australia
- Adding Reconciliation Day for ACT
- Updating Family and Community Day for ACT

This closes #249 and #251.